### PR TITLE
progress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,13 @@ endif()
 
 find_package(Qt6 6.5 REQUIRED COMPONENTS Widgets)
 
+# md4c (CommonMark + GFM markdown parser). We use the C library directly
+# rather than QTextDocument::setMarkdown because the latter bakes explicit
+# character formats into the document that override CSS supplied via
+# setDefaultStyleSheet.
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(MD4C_HTML REQUIRED IMPORTED_TARGET md4c-html)
+
 qt_standard_project_setup()
 
 qt_add_executable(mdv
@@ -36,9 +43,16 @@ qt_add_executable(mdv
     src/TabBar.h
     src/Theme.cpp
     src/Theme.h
+    src/ContentTheme.cpp
+    src/ContentTheme.h
+    src/Markdown.cpp
+    src/Markdown.h
+    src/PreferencesDialog.cpp
+    src/PreferencesDialog.h
+    resources/resources.qrc
 )
 
-target_link_libraries(mdv PRIVATE Qt6::Widgets)
+target_link_libraries(mdv PRIVATE Qt6::Widgets PkgConfig::MD4C_HTML)
 
 target_include_directories(mdv PRIVATE src)
 

--- a/qt.bash
+++ b/qt.bash
@@ -7,11 +7,12 @@
 set -euo pipefail
 
 PACKAGES=(
-    qt-creator      # the IDE
-    qt6-doc         # offline Qt 6 docs (browsable inside Creator)
-    ninja-build     # faster generator than make for CMake
-    gdb             # debugger Qt Creator drives
+    qt-creator         # the IDE
+    qt6-doc            # offline Qt 6 docs (browsable inside Creator)
+    ninja-build        # faster generator than make for CMake
+    gdb                # debugger Qt Creator drives
     clang-tools-extra  # clangd, for code model + completion
+    md4c-devel         # markdown → HTML (CommonMark + GFM)
 )
 
 if ! command -v dnf >/dev/null 2>&1; then

--- a/resources/content/content.qss.template
+++ b/resources/content/content.qss.template
@@ -1,0 +1,180 @@
+/* mdv.qt — Document content structural stylesheet.
+ *
+ * Placeholders @{key.path} are resolved at load time against:
+ *   - the active content theme JSON  (colors.*, spacing.*)
+ *   - QSettings                       (fonts.* — see ContentTheme::fontValue)
+ *
+ * Author the *structural* decisions here (border styles, padding shapes,
+ * font-style choices, etc.). Tunable values (colors, dimensions, font
+ * families) belong in the theme JSON or in user settings.
+ */
+
+/* Prose font (family + size) is applied via QTextDocument::setDefaultFont
+ * from DocumentView, not via CSS. Qt's stylesheet engine routes font
+ * properties through the document's default QFont rather than through
+ * `body { font-family }`, and the HTML fragments md4c produces don't
+ * contain a real <body> for the selector to bind to either way. */
+body {
+  color: @{text.foreground};
+  background-color: @{text.background};
+}
+
+h1 {
+  color: @{heading.foreground};
+  border-bottom: 1px solid @{heading.border};
+  padding-bottom: 0.3em;
+  font-weight: 200;
+  letter-spacing: 0.125rem;
+  margin-top: @{spacing.heading};
+}
+
+h2, h3, h4, h5, h6 {
+  color: @{heading.foreground};
+  font-weight: 200;
+  letter-spacing: 0.1rem;
+  margin-top: @{spacing.heading};
+}
+
+p {
+  margin: @{spacing.paragraph} 0;
+}
+
+a {
+  color: @{link.foreground};
+  text-decoration: underline;
+}
+
+ul, ol {
+  margin: @{spacing.paragraph} 0;
+  padding-left: @{spacing.list.indent};
+}
+
+blockquote {
+  color: @{blockquote.foreground};
+  background-color: @{blockquote.background};
+  border-left: 3px solid @{blockquote.border};
+  padding: 0.25em 0.75em;
+  margin: @{spacing.paragraph} 0;
+}
+
+hr {
+  background-color: @{hr.foreground};
+  height: 0.1rem;
+  border: none;
+}
+
+pre {
+  background-color: @{code.background};
+  border: 1px solid @{code.border};
+  border-radius: 6px;
+  padding: @{spacing.code.pad};
+  font-family: "@{fonts.mono}";
+  font-size: 0.92em;
+  white-space: pre;
+}
+
+code {
+  background-color: @{code.inline.background};
+  border: 1px dotted @{code.inline.outline};
+  border-radius: 4px;
+  padding: 0.1em 0.3em;
+  color: @{code.foreground};
+  font-family: "@{fonts.mono}";
+  font-size: 0.92em;
+}
+
+pre > code {
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  color: @{text.foreground};
+}
+
+table {
+  border-collapse: collapse;
+  margin: @{spacing.paragraph} 0;
+}
+
+th, td {
+  border-bottom: 1px dotted @{table.border};
+  padding: @{spacing.table.cell};
+  vertical-align: top;
+  text-align: left;
+}
+
+th {
+  background-color: @{table.header.background};
+  color: @{table.header.foreground};
+  border-bottom: 1px solid @{table.header.foreground};
+}
+
+/* Syntax highlight color slots — applied by KSyntaxHighlighting via a
+ * Theme adapter; same keys here let inline span-class fallback work
+ * if any HTML-side highlighting is rendered. */
+.hljs-keyword,
+.hljs-literal,
+.hljs-meta,
+.hljs-name {
+  color: @{syntax.keyword};
+}
+
+.hljs-string,
+.hljs-code,
+.hljs-meta .hljs-string {
+  color: @{syntax.string};
+}
+
+.hljs-comment,
+.hljs-quote,
+.hljs-formula {
+  color: @{syntax.comment};
+  font-style: italic;
+}
+
+.hljs-number {
+  color: @{syntax.number};
+}
+
+.hljs-title,
+.hljs-title.function_,
+.hljs-built_in {
+  color: @{syntax.function};
+}
+
+.hljs-type,
+.hljs-title.class_ {
+  color: @{syntax.type};
+}
+
+.hljs-variable,
+.hljs-attr,
+.hljs-attribute,
+.hljs-property {
+  color: @{syntax.variable};
+}
+
+.hljs-variable.constant_ {
+  color: @{syntax.constant};
+}
+
+.hljs-operator,
+.hljs-subst {
+  color: @{syntax.operator};
+}
+
+.hljs-regexp {
+  color: @{syntax.regex};
+}
+
+.hljs-tag {
+  color: @{syntax.tag};
+}
+
+.hljs-section,
+.hljs-strong {
+  font-weight: bold;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -1,0 +1,8 @@
+<RCC>
+  <qresource prefix="/">
+    <file>content/content.qss.template</file>
+    <file>themes/blackboard.content.json</file>
+    <file>themes/bubblegum-goth.content.json</file>
+    <file>themes/corporate.content.json</file>
+  </qresource>
+</RCC>

--- a/resources/themes/blackboard.content.json
+++ b/resources/themes/blackboard.content.json
@@ -1,0 +1,52 @@
+{
+  "name": "Blackboard",
+  "type": "dark",
+
+  "spacing": {
+    "paragraph":   "1em",
+    "heading":     "1.5em",
+    "list.indent": "1.5em",
+    "code.pad":    "0.75em 1em",
+    "table.cell":  "0.5em 1em"
+  },
+
+  "colors": {
+    "text.foreground":          "#bebebe",
+    "text.background":          "#0f0f0f",
+    "text.muted":               "#436d92",
+
+    "heading.foreground":       "#5d88af",
+    "heading.border":           "#5d88af66",
+
+    "link.foreground":          "#90bde5",
+    "link.underline":           "#5d88af40",
+
+    "code.foreground":          "#e4e4e7",
+    "code.background":          "#5d88af26",
+    "code.border":              "#5d88afbf",
+    "code.inline.background":   "#5d88af33",
+    "code.inline.outline":      "#5d88af66",
+
+    "blockquote.foreground":    "#e4e4e7",
+    "blockquote.border":        "#5d88af",
+    "blockquote.background":    "#18181b",
+
+    "table.border":             "#436d92bf",
+    "table.header.background":  "#18181b",
+    "table.header.foreground":  "#5d88af",
+
+    "hr.foreground":            "#5d88af26",
+
+    "syntax.keyword":           "#739abd",
+    "syntax.string":            "#be917f",
+    "syntax.comment":           "#636363",
+    "syntax.number":            "#8aa168",
+    "syntax.function":          "#a7a776",
+    "syntax.type":              "#59ab99",
+    "syntax.variable":          "#6ca1bc",
+    "syntax.constant":          "#509fbe",
+    "syntax.operator":          "#adadad",
+    "syntax.regex":             "#a16362",
+    "syntax.tag":               "#6ca1bc"
+  }
+}

--- a/resources/themes/bubblegum-goth.content.json
+++ b/resources/themes/bubblegum-goth.content.json
@@ -12,7 +12,7 @@
 
   "colors": {
     "text.foreground":          "#bebebe",
-    "text.background":          "#0f0f0f",
+    "text.background":          "#ff0000",
     "text.muted":               "#d750b2",
 
     "heading.foreground":       "#ff75d7",

--- a/resources/themes/bubblegum-goth.content.json
+++ b/resources/themes/bubblegum-goth.content.json
@@ -1,0 +1,52 @@
+{
+  "name": "Bubblegum Goth",
+  "type": "dark",
+
+  "spacing": {
+    "paragraph":   "1em",
+    "heading":     "1.5em",
+    "list.indent": "1.5em",
+    "code.pad":    "0.75em 1em",
+    "table.cell":  "0.5em 1em"
+  },
+
+  "colors": {
+    "text.foreground":          "#bebebe",
+    "text.background":          "#0f0f0f",
+    "text.muted":               "#d750b2",
+
+    "heading.foreground":       "#ff75d7",
+    "heading.border":           "#ff75d766",
+
+    "link.foreground":          "#ffb9ff",
+    "link.underline":           "#ff75d740",
+
+    "code.foreground":          "#e4e4e7",
+    "code.background":          "#ff75d726",
+    "code.border":              "#ff75d7bf",
+    "code.inline.background":   "#ff75d733",
+    "code.inline.outline":      "#ff75d766",
+
+    "blockquote.foreground":    "#e4e4e7",
+    "blockquote.border":        "#ff75d7",
+    "blockquote.background":    "#18181b",
+
+    "table.border":             "#d750b2bf",
+    "table.header.background":  "#18181b",
+    "table.header.foreground":  "#ff75d7",
+
+    "hr.foreground":            "#ff75d726",
+
+    "syntax.keyword":           "#739abd",
+    "syntax.string":            "#be917f",
+    "syntax.comment":           "#636363",
+    "syntax.number":            "#8aa168",
+    "syntax.function":          "#a7a776",
+    "syntax.type":              "#59ab99",
+    "syntax.variable":          "#6ca1bc",
+    "syntax.constant":          "#509fbe",
+    "syntax.operator":          "#adadad",
+    "syntax.regex":             "#a16362",
+    "syntax.tag":               "#6ca1bc"
+  }
+}

--- a/resources/themes/bubblegum-goth.content.json
+++ b/resources/themes/bubblegum-goth.content.json
@@ -12,7 +12,7 @@
 
   "colors": {
     "text.foreground":          "#bebebe",
-    "text.background":          "#ff0000",
+    "text.background":          "#0f0f0f",
     "text.muted":               "#d750b2",
 
     "heading.foreground":       "#ff75d7",

--- a/resources/themes/corporate.content.json
+++ b/resources/themes/corporate.content.json
@@ -1,0 +1,52 @@
+{
+  "name": "Corporate",
+  "type": "dark",
+
+  "spacing": {
+    "paragraph":   "1em",
+    "heading":     "1.5em",
+    "list.indent": "1.5em",
+    "code.pad":    "0.75em 1em",
+    "table.cell":  "0.5em 1em"
+  },
+
+  "colors": {
+    "text.foreground":          "#bebebe",
+    "text.background":          "#0f0f0f",
+    "text.muted":               "#006868",
+
+    "heading.foreground":       "#5dafae",
+    "heading.border":           "#00808066",
+
+    "link.foreground":          "#5dafae",
+    "link.underline":           "#00808040",
+
+    "code.foreground":          "#e4e4e7",
+    "code.background":          "#00808026",
+    "code.border":              "#008080bf",
+    "code.inline.background":   "#00808033",
+    "code.inline.outline":      "#00808066",
+
+    "blockquote.foreground":    "#e4e4e7",
+    "blockquote.border":        "#008080",
+    "blockquote.background":    "#18181b",
+
+    "table.border":             "#006868bf",
+    "table.header.background":  "#18181b",
+    "table.header.foreground":  "#5dafae",
+
+    "hr.foreground":            "#00808026",
+
+    "syntax.keyword":           "#739abd",
+    "syntax.string":            "#be917f",
+    "syntax.comment":           "#636363",
+    "syntax.number":            "#8aa168",
+    "syntax.function":          "#a7a776",
+    "syntax.type":              "#59ab99",
+    "syntax.variable":          "#6ca1bc",
+    "syntax.constant":          "#509fbe",
+    "syntax.operator":          "#adadad",
+    "syntax.regex":             "#a16362",
+    "syntax.tag":               "#6ca1bc"
+  }
+}

--- a/src/ContentTheme.cpp
+++ b/src/ContentTheme.cpp
@@ -1,0 +1,172 @@
+#include "ContentTheme.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QRegularExpression>
+#include <QSettings>
+#include <QStringList>
+
+namespace {
+
+QString readResourceText(const QString &path) {
+  QFile f(path);
+  if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) return {};
+  return QString::fromUtf8(f.readAll());
+}
+
+// Section objects in the JSON use dotted flat keys ("text.foreground"),
+// so this is just a string-only copy into a QHash.
+QHash<QString, QString> flatten(const QJsonObject &obj) {
+  QHash<QString, QString> out;
+  for (auto it = obj.begin(); it != obj.end(); ++it) {
+    if (it->isString()) out.insert(it.key(), it->toString());
+  }
+  return out;
+}
+
+// Qt's CSS parser reads 8-digit hex colors as #AARRGGBB (Android style)
+// instead of CSS3's #RRGGBBAA. So a theme author writing the standard
+// "#f472b633" (pink at 20%) actually gets parsed as alpha=0xf4, R=0x72,
+// G=0xb6, B=0x33 — olive green. Rotate the trailing alpha byte to the
+// front so what Qt parses matches what the author meant. Pass through
+// anything that's not an 8-digit hex (#RGB, #RRGGBB, rgba(), named).
+QString coerceColor(const QString &value) {
+  static const QRegularExpression re(
+      QStringLiteral("^#([0-9a-fA-F]{6})([0-9a-fA-F]{2})$"));
+  const auto m = re.match(value);
+  if (!m.hasMatch()) return value;
+  return QStringLiteral("#%1%2").arg(m.captured(2), m.captured(1));
+}
+
+}  // namespace
+
+bool ContentTheme::loadBundled(const QString &name) {
+  return loadFile(QStringLiteral(":/themes/%1.content.json").arg(name));
+}
+
+bool ContentTheme::loadFile(const QString &path) {
+  QFile f(path);
+  if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) return false;
+
+  QJsonParseError err{};
+  const auto doc = QJsonDocument::fromJson(f.readAll(), &err);
+  if (err.error != QJsonParseError::NoError || !doc.isObject()) return false;
+
+  const QJsonObject root = doc.object();
+  m_name = root.value("name").toString();
+  m_type = root.value("type").toString();
+  m_colors = flatten(root.value("colors").toObject());
+  m_spacing = flatten(root.value("spacing").toObject());
+  return true;
+}
+
+QString ContentTheme::color(const QString &key) const {
+  return m_colors.value(key);
+}
+
+QString ContentTheme::spacing(const QString &key) const {
+  return m_spacing.value(key);
+}
+
+QString ContentTheme::fontValue(const QString &key) const {
+  // Placeholder keys arrive as fonts.prose / fonts.prose.size, etc.
+  // QSettings uses '/' as the path separator, so map dotted → slashed.
+  QString settingsKey = key;
+  settingsKey.replace('.', '/');
+
+  QString stored = QSettings().value(settingsKey).toString();
+  if (!stored.isEmpty()) {
+    // The size dialog stores a bare integer (e.g. "14"); the CSS needs
+    // a unit. Append px if missing.
+    if (key.endsWith(QStringLiteral(".size")) &&
+        !stored.endsWith(QStringLiteral("px")) &&
+        !stored.endsWith(QStringLiteral("pt"))) {
+      stored += QStringLiteral("px");
+    }
+    return stored;
+  }
+
+  if (key == "fonts.prose")      return QStringLiteral("sans-serif");
+  if (key == "fonts.mono")       return QStringLiteral("monospace");
+  if (key == "fonts.prose.size") return QStringLiteral("14px");
+  // fonts.mono.size is no longer referenced by the template (mono
+  // inherits relative size in em) but keep the fallback in case any
+  // future stylesheet wants it.
+  if (key == "fonts.mono.size")  return QStringLiteral("13px");
+  return {};
+}
+
+QString ContentTheme::resolveKey(const QString &key) const {
+  if (key.startsWith(QStringLiteral("fonts."))) return fontValue(key);
+
+  if (key.startsWith(QStringLiteral("spacing."))) {
+    return m_spacing.value(key.mid(8));  // strip "spacing."
+  }
+
+  // Anything else is a color key. Bare ("text.foreground") in the
+  // template — looked up directly in the flattened colors map, then
+  // run through coerceColor so 8-digit hex authored as #RRGGBBAA gets
+  // rotated to Qt's #AARRGGBB ordering.
+  return coerceColor(m_colors.value(key));
+}
+
+QString ContentTheme::qss() const {
+  const QString tpl = readResourceText(":/content/content.qss.template");
+  static const QRegularExpression re(QStringLiteral(R"(@\{([^}]+)\})"));
+
+  QString out;
+  out.reserve(tpl.size());
+  qsizetype pos = 0;
+  auto it = re.globalMatch(tpl);
+  while (it.hasNext()) {
+    const auto m = it.next();
+    out.append(tpl.mid(pos, m.capturedStart() - pos));
+    out.append(resolveKey(m.captured(1)));
+    pos = m.capturedEnd();
+  }
+  out.append(tpl.mid(pos));
+  return out;
+}
+
+void ContentTheme::reload() {
+  const QString name =
+      QSettings().value(QStringLiteral("theme/content"), QStringLiteral("blackboard"))
+          .toString();
+  loadBundled(name);
+}
+
+QStringList ContentTheme::availableThemes() {
+  QStringList names;
+  QDir bundled(QStringLiteral(":/themes"));
+  const auto files =
+      bundled.entryInfoList({QStringLiteral("*.content.json")}, QDir::Files);
+  for (const QFileInfo &fi : files) names << fi.baseName();
+  names.sort();
+  return names;
+}
+
+QString ContentTheme::displayNameForBundled(const QString &id) {
+  QFile f(QStringLiteral(":/themes/%1.content.json").arg(id));
+  if (!f.open(QIODevice::ReadOnly | QIODevice::Text)) return id;
+
+  QJsonParseError err{};
+  const auto doc = QJsonDocument::fromJson(f.readAll(), &err);
+  if (err.error != QJsonParseError::NoError || !doc.isObject()) return id;
+
+  const QString name = doc.object().value(QStringLiteral("name")).toString();
+  return name.isEmpty() ? id : name;
+}
+
+ContentTheme &ContentTheme::active() {
+  static ContentTheme instance;
+  static bool initialized = false;
+  if (!initialized) {
+    instance.reload();
+    initialized = true;
+  }
+  return instance;
+}

--- a/src/ContentTheme.cpp
+++ b/src/ContentTheme.cpp
@@ -73,10 +73,20 @@ QString ContentTheme::spacing(const QString &key) const {
 }
 
 QString ContentTheme::fontValue(const QString &key) const {
-  // Placeholder keys arrive as fonts.prose / fonts.prose.size, etc.
-  // QSettings uses '/' as the path separator, so map dotted → slashed.
-  QString settingsKey = key;
-  settingsKey.replace('.', '/');
+  // Placeholder keys arrive as "fonts.prose" or "fonts.prose.size".
+  // QSettings treats '/' as a group separator, so we only convert the
+  // *first* dot (the section/key boundary) — leaving any further dots
+  // intact lets a key like "fonts.prose.size" map to QSettings path
+  // "fonts/prose.size" (group "fonts", key "prose.size"), which is
+  // where PreferencesDialog::saveToSettings actually writes it.
+  // Blindly replacing every dot would mis-route it to a non-existent
+  // "fonts/prose/size" subgroup.
+  const int firstDot = key.indexOf(QLatin1Char('.'));
+  const QString settingsKey =
+      (firstDot < 0)
+          ? key
+          : QStringLiteral("%1/%2").arg(key.left(firstDot),
+                                        key.mid(firstDot + 1));
 
   QString stored = QSettings().value(settingsKey).toString();
   if (!stored.isEmpty()) {

--- a/src/ContentTheme.cpp
+++ b/src/ContentTheme.cpp
@@ -146,7 +146,17 @@ void ContentTheme::reload() {
   const QString name =
       QSettings().value(QStringLiteral("theme/content"), QStringLiteral("blackboard"))
           .toString();
-  loadBundled(name);
+  if (loadBundled(name)) return;
+
+  qWarning("ContentTheme: failed to load bundled theme '%s'",
+           qPrintable(name));
+
+  // Fall back to the canonical default so the document still renders
+  // with a sensible theme rather than an empty stylesheet (which would
+  // emit invalid CSS like `color: ;` for every @{...} placeholder).
+  if (name != QStringLiteral("blackboard")) {
+    loadBundled(QStringLiteral("blackboard"));
+  }
 }
 
 QStringList ContentTheme::availableThemes() {

--- a/src/ContentTheme.h
+++ b/src/ContentTheme.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <QHash>
+#include <QString>
+
+// Loads a content theme JSON, resolves the structural QSS template against
+// it (plus font values from QSettings), and exposes the final stylesheet
+// for setDefaultStyleSheet on a QTextDocument.
+//
+// Placeholder syntax inside the template is `@{key}`. The resolver routes
+// keys to one of three sources based on prefix:
+//   fonts.*     → QSettings (e.g. fonts/prose, fonts/mono.size)
+//   spacing.*   → the active theme's "spacing" section
+//   <other>     → the active theme's "colors" section
+//
+// One global ContentTheme is exposed via active(); DocumentView constructs
+// apply its qss() to their QTextDocument.
+class ContentTheme {
+public:
+  ContentTheme() = default;
+
+  // Load a theme bundled in the qrc by name. Looks at
+  // :/themes/<name>.content.json. Returns true on success.
+  bool loadBundled(const QString &name);
+
+  // Load a theme from an arbitrary path on disk.
+  bool loadFile(const QString &path);
+
+  // Re-read the currently-selected theme name from QSettings
+  // ("theme/content", default "blackboard") and reload the JSON. Used
+  // by the Preferences dialog to react to changes.
+  void reload();
+
+  // List of bundled theme ids (e.g. "blackboard", "bubblegum-goth").
+  // Walks :/themes/ and strips the .content.json suffix.
+  static QStringList availableThemes();
+
+  // The human-readable "name" field from the bundled theme's JSON
+  // (e.g. "Blackboard" for the "blackboard" id). Falls back to the id
+  // verbatim if the JSON is missing or doesn't set a name.
+  static QString displayNameForBundled(const QString &id);
+
+  // Resolved stylesheet ready for QTextDocument::setDefaultStyleSheet.
+  QString qss() const;
+
+  // Individual accessors — useful for the KSyntaxHighlighting Theme
+  // adapter we'll add later.
+  QString color(const QString &key) const;
+  QString spacing(const QString &key) const;
+
+  QString name() const { return m_name; }
+  QString type() const { return m_type; }
+
+  // Process-wide active theme. Lazily loads "blackboard" on first call.
+  static ContentTheme &active();
+
+private:
+  QString resolveKey(const QString &key) const;
+  QString fontValue(const QString &key) const;
+
+  QString m_name;
+  QString m_type;
+  QHash<QString, QString> m_colors;
+  QHash<QString, QString> m_spacing;
+};

--- a/src/DocumentView.cpp
+++ b/src/DocumentView.cpp
@@ -3,9 +3,11 @@
 #include <QAbstractTextDocumentLayout>
 #include <QFile>
 #include <QFileInfo>
+#include <QFont>
 #include <QMenu>
 #include <QMessageBox>
 #include <QScrollBar>
+#include <QSettings>
 #include <QTextBlock>
 #include <QTextBrowser>
 #include <QTextCursor>
@@ -13,7 +15,9 @@
 #include <QTimer>
 #include <QVBoxLayout>
 
+#include "ContentTheme.h"
 #include "EditorPane.h"
+#include "Markdown.h"
 
 DocumentView::DocumentView(QWidget *parent) : QWidget(parent) {
   auto *layout = new QVBoxLayout(this);
@@ -22,6 +26,16 @@ DocumentView::DocumentView(QWidget *parent) : QWidget(parent) {
   m_browser = new QTextBrowser(this);
   m_browser->setOpenExternalLinks(true);
   m_browser->setContextMenuPolicy(Qt::CustomContextMenu);
+  // Disable QTextBrowser's own drop handling so file URL drops bubble
+  // up to the EditorPane (which interprets them as "open this file")
+  // instead of being inserted as text into the rendered document.
+  m_browser->setAcceptDrops(false);
+  // Apply the active content theme's stylesheet. setDefaultStyleSheet
+  // persists across subsequent setHtml() calls on the same document.
+  m_browser->document()->setDefaultStyleSheet(ContentTheme::active().qss());
+  // Prose font goes through the document's default QFont — CSS body
+  // rules don't reliably set font properties on QTextDocument.
+  applyDocumentFont();
   connect(m_browser, &QWidget::customContextMenuRequested, this,
           &DocumentView::onContextMenuRequested);
   layout->addWidget(m_browser);
@@ -53,8 +67,10 @@ bool DocumentView::loadFile(const QString &path) {
 
   QTextStream in(&file);
   in.setEncoding(QStringConverter::Utf8);
-  m_browser->document()->setMarkdown(in.readAll(),
-                                     QTextDocument::MarkdownDialectGitHub);
+  // Render markdown → HTML externally (via md4c) and feed setHtml, so
+  // the document's default stylesheet actually applies. setMarkdown
+  // would bypass CSS by baking in QTextCharFormats during import.
+  m_browser->setHtml(mdv::markdownToHtml(in.readAll()));
 
   // QTextBrowser parks the text cursor wherever setMarkdown leaves it
   // and then scrolls to keep the cursor visible, which often lands at
@@ -74,6 +90,36 @@ bool DocumentView::loadFile(const QString &path) {
 
   emit fileLoaded(m_filePath);
   return true;
+}
+
+void DocumentView::refresh() {
+  // Re-pull the stylesheet (theme or font settings may have changed
+  // since construction).
+  m_browser->document()->setDefaultStyleSheet(ContentTheme::active().qss());
+  applyDocumentFont();
+
+  if (m_filePath.isEmpty()) return;
+
+  // Capture position before re-rendering; restore via the same anchor
+  // machinery the Split actions use.
+  const int anchor = topAnchor();
+  loadFile(m_filePath);
+  scrollToAnchor(anchor);
+}
+
+void DocumentView::applyDocumentFont() {
+  QSettings s;
+  QFont f = m_browser->document()->defaultFont();
+
+  const QString family = s.value(QStringLiteral("fonts/prose")).toString();
+  if (!family.isEmpty()) f.setFamily(family);
+
+  // Settings store an integer (the spinbox value). Use setPointSize so
+  // Ctrl+wheel zoomIn/zoomOut — which works in points — scales it.
+  const int size = s.value(QStringLiteral("fonts/prose.size"), 14).toInt();
+  f.setPointSize(size);
+
+  m_browser->document()->setDefaultFont(f);
 }
 
 int DocumentView::topAnchor() const {

--- a/src/DocumentView.cpp
+++ b/src/DocumentView.cpp
@@ -1,11 +1,13 @@
 #include "DocumentView.h"
 
 #include <QAbstractTextDocumentLayout>
+#include <QColor>
 #include <QFile>
 #include <QFileInfo>
 #include <QFont>
 #include <QMenu>
 #include <QMessageBox>
+#include <QPalette>
 #include <QScrollBar>
 #include <QSettings>
 #include <QTextBlock>
@@ -36,6 +38,9 @@ DocumentView::DocumentView(QWidget *parent) : QWidget(parent) {
   // Prose font goes through the document's default QFont — CSS body
   // rules don't reliably set font properties on QTextDocument.
   applyDocumentFont();
+  // Page background lives on the widget's QPalette::Base, not in the
+  // document's CSS — see applyDocumentPalette() comment.
+  applyDocumentPalette();
   connect(m_browser, &QWidget::customContextMenuRequested, this,
           &DocumentView::onContextMenuRequested);
   layout->addWidget(m_browser);
@@ -97,6 +102,7 @@ void DocumentView::refresh() {
   // since construction).
   m_browser->document()->setDefaultStyleSheet(ContentTheme::active().qss());
   applyDocumentFont();
+  applyDocumentPalette();
 
   if (m_filePath.isEmpty()) return;
 
@@ -120,6 +126,21 @@ void DocumentView::applyDocumentFont() {
   f.setPointSize(size);
 
   m_browser->document()->setDefaultFont(f);
+}
+
+void DocumentView::applyDocumentPalette() {
+  // body { background-color } in the document's CSS doesn't paint the
+  // viewport — QTextBrowser draws the viewport using the widget's
+  // QPalette::Base. Pull the theme's text.background / text.foreground
+  // through the palette so the page color shows. Element-level CSS
+  // rules in the template still win for headings, code, etc.
+  const QString bg = ContentTheme::active().color(QStringLiteral("text.background"));
+  const QString fg = ContentTheme::active().color(QStringLiteral("text.foreground"));
+
+  QPalette p = m_browser->palette();
+  if (!bg.isEmpty()) p.setColor(QPalette::Base, QColor(bg));
+  if (!fg.isEmpty()) p.setColor(QPalette::Text, QColor(fg));
+  m_browser->setPalette(p);
 }
 
 int DocumentView::topAnchor() const {

--- a/src/DocumentView.h
+++ b/src/DocumentView.h
@@ -13,6 +13,17 @@ public:
 
   bool loadFile(const QString &path);
 
+  // Re-apply the active content theme's stylesheet and re-render the
+  // current file's HTML so the new styles take effect. Used when the
+  // Preferences dialog changes theme or fonts. No-op if no file is loaded.
+  void refresh();
+
+  // Read fonts/prose and fonts/prose.size from QSettings and apply via
+  // QTextDocument::setDefaultFont. Mono font/size live in the CSS
+  // (font-family on pre/code, font-size: 0.92em relative). Called on
+  // construction and on Preferences-applied.
+  void applyDocumentFont();
+
   // Canonical (symlink-resolved) absolute path, or empty if no file is loaded.
   QString filePath() const { return m_filePath; }
 

--- a/src/DocumentView.h
+++ b/src/DocumentView.h
@@ -24,6 +24,12 @@ public:
   // construction and on Preferences-applied.
   void applyDocumentFont();
 
+  // Push text.background / text.foreground from the active theme into
+  // the QTextBrowser's QPalette. The viewport background is the
+  // widget's palette Base role, not the document's CSS, so we have to
+  // apply it here for the page color to take effect.
+  void applyDocumentPalette();
+
   // Canonical (symlink-resolved) absolute path, or empty if no file is loaded.
   QString filePath() const { return m_filePath; }
 

--- a/src/EditorArea.cpp
+++ b/src/EditorArea.cpp
@@ -223,6 +223,7 @@ void EditorArea::registerPane(EditorPane *pane) {
   connect(pane, &EditorPane::currentDocumentChanged, this,
           &EditorArea::onPaneCurrentDocumentChanged);
   connect(pane, &EditorPane::tabClosed, this, &EditorArea::onTabClosed);
+  connect(pane, &EditorPane::filesDropped, this, &EditorArea::filesDropped);
 }
 
 void EditorArea::onTabClosed(const QString &filePath) {

--- a/src/EditorArea.h
+++ b/src/EditorArea.h
@@ -51,6 +51,11 @@ public:
 signals:
   void currentDocumentChanged(DocumentView *doc);
 
+  // Re-emission of an EditorPane's filesDropped signal — the active
+  // pane has already been set before this fires, so subscribers can
+  // route through their normal openFile path.
+  void filesDropped(const QStringList &paths);
+
 private slots:
   void onPaneActivated();
   void onPaneEmpty();

--- a/src/EditorPane.cpp
+++ b/src/EditorPane.cpp
@@ -13,6 +13,7 @@
 #include <QPaintEvent>
 #include <QPainter>
 #include <QTabBar>
+#include <QUrl>
 
 #include "DocumentView.h"
 #include "EditorArea.h"
@@ -185,37 +186,50 @@ void EditorPane::onCurrentChanged(int index) {
 }
 
 void EditorPane::dragEnterEvent(QDragEnterEvent *e) {
-  if (!e->mimeData()->hasFormat(TabBar::mimeType())) return;
-
-  // Cache source so we don't decode on every dragMove.
-  QByteArray payload = e->mimeData()->data(TabBar::mimeType());
-  QDataStream ds(payload);
-  qintptr ptr = 0;
-  qint32 idx = -1;
-  ds >> ptr >> idx;
-  m_dragSource = reinterpret_cast<EditorPane *>(ptr);
-
-  e->acceptProposedAction();
-}
-
-void EditorPane::dragMoveEvent(QDragMoveEvent *e) {
-  if (!e->mimeData()->hasFormat(TabBar::mimeType())) return;
-
-  const DropZone zone = zoneAt(e->position().toPoint());
-
-  // Same-pane center: the tab is already here, nothing to do. No
-  // overlay, ignore the move so the OS shows a "no-drop" cursor.
-  const bool noop = zone == ZoneNone ||
-                    (m_dragSource == this && zone == ZoneTab);
-
-  if (noop) {
-    hideDropOverlay();
-    e->ignore();
+  if (e->mimeData()->hasFormat(TabBar::mimeType())) {
+    QByteArray payload = e->mimeData()->data(TabBar::mimeType());
+    QDataStream ds(payload);
+    qintptr ptr = 0;
+    qint32 idx = -1;
+    ds >> ptr >> idx;
+    m_dragSource = reinterpret_cast<EditorPane *>(ptr);
+    e->acceptProposedAction();
     return;
   }
 
-  showDropOverlay(zone);
-  e->acceptProposedAction();
+  // OS file drag — accept anything that carries local file URLs. We
+  // don't show the split-zone overlay for OS drops; the entire pane
+  // is the drop target.
+  if (e->mimeData()->hasUrls()) {
+    for (const QUrl &url : e->mimeData()->urls()) {
+      if (url.isLocalFile()) {
+        e->acceptProposedAction();
+        return;
+      }
+    }
+  }
+}
+
+void EditorPane::dragMoveEvent(QDragMoveEvent *e) {
+  if (e->mimeData()->hasFormat(TabBar::mimeType())) {
+    const DropZone zone = zoneAt(e->position().toPoint());
+    // Same-pane center: tab is already here. No overlay; ignore the
+    // move so the OS shows a "no-drop" cursor.
+    const bool noop = zone == ZoneNone ||
+                      (m_dragSource == this && zone == ZoneTab);
+    if (noop) {
+      hideDropOverlay();
+      e->ignore();
+      return;
+    }
+    showDropOverlay(zone);
+    e->acceptProposedAction();
+    return;
+  }
+
+  if (e->mimeData()->hasUrls()) {
+    e->acceptProposedAction();
+  }
 }
 
 void EditorPane::dragLeaveEvent(QDragLeaveEvent *) {
@@ -225,6 +239,24 @@ void EditorPane::dragLeaveEvent(QDragLeaveEvent *) {
 
 void EditorPane::dropEvent(QDropEvent *e) {
   hideDropOverlay();
+
+  // OS file drop — handled separately from internal tab drags.
+  if (e->mimeData()->hasUrls() &&
+      !e->mimeData()->hasFormat(TabBar::mimeType())) {
+    QStringList paths;
+    for (const QUrl &url : e->mimeData()->urls()) {
+      if (url.isLocalFile()) paths << url.toLocalFile();
+    }
+    if (!paths.isEmpty()) {
+      // Take focus so this pane becomes active before the open routes
+      // through openFile() — that way the file opens in the pane the
+      // user actually dropped on.
+      setFocus();
+      emit filesDropped(paths);
+      e->acceptProposedAction();
+    }
+    return;
+  }
 
   if (!e->mimeData()->hasFormat(TabBar::mimeType())) return;
 

--- a/src/EditorPane.h
+++ b/src/EditorPane.h
@@ -62,6 +62,10 @@ signals:
   // moves (drag-out to another pane goes through takeDocument()).
   void tabClosed(const QString &filePath);
 
+  // Emitted when the user drops one or more file URLs onto this pane
+  // from the OS. The pane has already focused itself before emitting.
+  void filesDropped(const QStringList &paths);
+
 protected:
   void focusInEvent(QFocusEvent *e) override;
   void mousePressEvent(QMouseEvent *e) override;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1,16 +1,22 @@
 #include "MainWindow.h"
 
 #include <QAction>
+#include <QDragEnterEvent>
+#include <QDropEvent>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QMenu>
 #include <QMenuBar>
+#include <QMimeData>
 #include <QSettings>
 #include <QStatusBar>
+#include <QUrl>
 
+#include "ContentTheme.h"
 #include "DocumentView.h"
 #include "EditorArea.h"
 #include "EditorPane.h"
+#include "PreferencesDialog.h"
 
 namespace {
 constexpr int kRecentFilesLimit = 10;
@@ -25,6 +31,15 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   setCentralWidget(m_area);
   connect(m_area, &EditorArea::currentDocumentChanged, this,
           &MainWindow::onCurrentDocumentChanged);
+  connect(m_area, &EditorArea::filesDropped, this,
+          [this](const QStringList &paths) {
+            for (const QString &p : paths) openFile(p);
+          });
+
+  // Catch-all for drops that miss the EditorArea (menubar, status bar,
+  // any chrome). Drops anywhere on the window get routed to the
+  // currently active pane via openFile().
+  setAcceptDrops(true);
 
   auto *fileMenu = menuBar()->addMenu(tr("&File"));
 
@@ -58,6 +73,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   auto *reopenAction = fileMenu->addAction(tr("Reopen Closed &Tab"));
   reopenAction->setShortcut(QKeySequence(tr("Ctrl+Shift+T")));
   connect(reopenAction, &QAction::triggered, this, &MainWindow::onReopenClosed);
+
+  fileMenu->addSeparator();
+
+  auto *prefsAction = fileMenu->addAction(tr("&Preferences..."));
+  prefsAction->setShortcut(QKeySequence::Preferences);
+  connect(prefsAction, &QAction::triggered, this, &MainWindow::onPreferences);
 
   fileMenu->addSeparator();
 
@@ -103,6 +124,24 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
 
 MainWindow::~MainWindow() = default;
 
+void MainWindow::dragEnterEvent(QDragEnterEvent *e) {
+  if (!e->mimeData()->hasUrls()) return;
+  for (const QUrl &url : e->mimeData()->urls()) {
+    if (url.isLocalFile()) {
+      e->acceptProposedAction();
+      return;
+    }
+  }
+}
+
+void MainWindow::dropEvent(QDropEvent *e) {
+  if (!e->mimeData()->hasUrls()) return;
+  for (const QUrl &url : e->mimeData()->urls()) {
+    if (url.isLocalFile()) openFile(url.toLocalFile());
+  }
+  e->acceptProposedAction();
+}
+
 void MainWindow::onOpen() {
   const QStringList paths = QFileDialog::getOpenFileNames(
       this, tr("Open Markdown Files"), QString(),
@@ -128,6 +167,24 @@ void MainWindow::onCloseAllInActive() { m_area->closeAllInActive(); }
 void MainWindow::onCloseAllEverywhere() { m_area->closeAllEverywhere(); }
 
 void MainWindow::onReopenClosed() { m_area->reopenLastClosed(); }
+
+void MainWindow::onPreferences() {
+  if (!m_preferencesDialog) {
+    m_preferencesDialog = new PreferencesDialog(this);
+    connect(m_preferencesDialog, &PreferencesDialog::preferencesApplied, this,
+            &MainWindow::onPreferencesApplied);
+  }
+  m_preferencesDialog->exec();
+}
+
+void MainWindow::onPreferencesApplied() {
+  // Theme name may have changed in QSettings; pull the new values into
+  // the singleton, then push the resulting stylesheet to every open
+  // DocumentView (they each re-render to pick up the new rules).
+  ContentTheme::active().reload();
+  const auto docs = findChildren<DocumentView *>();
+  for (DocumentView *doc : docs) doc->refresh();
+}
 
 void MainWindow::onSplitRight() {
   m_area->splitActive(EditorArea::Right);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -136,10 +136,18 @@ void MainWindow::dragEnterEvent(QDragEnterEvent *e) {
 
 void MainWindow::dropEvent(QDropEvent *e) {
   if (!e->mimeData()->hasUrls()) return;
+  // Only accept the drop if we actually opened something. Accepting on
+  // a Move action when no local files were present can cause the drag
+  // source to remove the originals — drag-source-side will think we
+  // took ownership.
+  bool accepted = false;
   for (const QUrl &url : e->mimeData()->urls()) {
-    if (url.isLocalFile()) openFile(url.toLocalFile());
+    if (url.isLocalFile()) {
+      openFile(url.toLocalFile());
+      accepted = true;
+    }
   }
-  e->acceptProposedAction();
+  if (accepted) e->acceptProposedAction();
 }
 
 void MainWindow::onOpen() {
@@ -174,6 +182,10 @@ void MainWindow::onPreferences() {
     connect(m_preferencesDialog, &PreferencesDialog::preferencesApplied, this,
             &MainWindow::onPreferencesApplied);
   }
+  // Always reload from settings before opening. Without this, edits the
+  // user made and then Cancelled would persist in the dialog's widgets
+  // and surface again next time it opens.
+  m_preferencesDialog->reload();
   m_preferencesDialog->exec();
 }
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -5,6 +5,7 @@
 
 class DocumentView;
 class EditorArea;
+class PreferencesDialog;
 class QMenu;
 
 class MainWindow : public QMainWindow {
@@ -17,6 +18,10 @@ public:
   // Open in the active editor pane. Returns the DocumentView the user is
   // now looking at, or nullptr on load failure.
   DocumentView *openFile(const QString &path);
+
+protected:
+  void dragEnterEvent(QDragEnterEvent *e) override;
+  void dropEvent(QDropEvent *e) override;
 
 private slots:
   void onOpen();
@@ -32,6 +37,8 @@ private slots:
   void onMoveTabLeft();
   void onCurrentDocumentChanged(DocumentView *doc);
   void rebuildRecentMenu();
+  void onPreferences();
+  void onPreferencesApplied();
 
 private:
   void loadRecentFiles();
@@ -41,4 +48,5 @@ private:
   EditorArea *m_area = nullptr;
   QMenu *m_recentMenu = nullptr;
   QStringList m_recentFiles;
+  PreferencesDialog *m_preferencesDialog = nullptr;
 };

--- a/src/Markdown.cpp
+++ b/src/Markdown.cpp
@@ -3,10 +3,13 @@
 #include <md4c-html.h>
 
 #include <QByteArray>
+#include <QLoggingCategory>
 
 namespace mdv {
 
 namespace {
+
+Q_LOGGING_CATEGORY(lcMarkdown, "mdv.markdown")
 
 void appendChunk(const MD_CHAR *text, MD_SIZE size, void *userData) {
   auto *out = static_cast<QByteArray *>(userData);
@@ -27,8 +30,19 @@ QString markdownToHtml(const QString &markdown) {
   QByteArray html;
   html.reserve(utf8.size() * 2);
 
-  md_html(utf8.constData(), static_cast<MD_SIZE>(utf8.size()), appendChunk,
-          &html, parserFlags, rendererFlags);
+  const int rc = md_html(utf8.constData(), static_cast<MD_SIZE>(utf8.size()),
+                         appendChunk, &html, parserFlags, rendererFlags);
+
+  // md_html returns 0 on success, -1 on failure. On failure the output
+  // is incomplete or empty, which would let DocumentView push a blank
+  // setHtml and show nothing. Fall back to a plain-text rendering of the
+  // raw markdown so the user at least sees the content (and the warning
+  // tells them something went wrong).
+  if (rc != 0) {
+    qCWarning(lcMarkdown) << "md4c parse failed (rc=" << rc
+                          << "), falling back to plain-text rendering";
+    return QStringLiteral("<pre>%1</pre>").arg(markdown.toHtmlEscaped());
+  }
 
   return QString::fromUtf8(html);
 }

--- a/src/Markdown.cpp
+++ b/src/Markdown.cpp
@@ -1,0 +1,36 @@
+#include "Markdown.h"
+
+#include <md4c-html.h>
+
+#include <QByteArray>
+
+namespace mdv {
+
+namespace {
+
+void appendChunk(const MD_CHAR *text, MD_SIZE size, void *userData) {
+  auto *out = static_cast<QByteArray *>(userData);
+  out->append(text, static_cast<int>(size));
+}
+
+}  // namespace
+
+QString markdownToHtml(const QString &markdown) {
+  const QByteArray utf8 = markdown.toUtf8();
+
+  // GFM dialect — tables, task lists, strikethrough, autolinks — matches
+  // what Qt's setMarkdown was doing.
+  constexpr unsigned parserFlags = MD_DIALECT_GITHUB;
+  // No special render flags — we want a clean HTML fragment.
+  constexpr unsigned rendererFlags = 0;
+
+  QByteArray html;
+  html.reserve(utf8.size() * 2);
+
+  md_html(utf8.constData(), static_cast<MD_SIZE>(utf8.size()), appendChunk,
+          &html, parserFlags, rendererFlags);
+
+  return QString::fromUtf8(html);
+}
+
+}  // namespace mdv

--- a/src/Markdown.h
+++ b/src/Markdown.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QString>
+
+// Markdown → HTML rendering helpers built on md4c-html.
+//
+// We don't use QTextDocument::setMarkdown because Qt's importer bakes
+// explicit QTextCharFormat values into the document that override any
+// CSS supplied via setDefaultStyleSheet (so prose / heading / code
+// theming would silently no-op). Rendering markdown to clean HTML
+// externally and then calling setHtml lets the document's stylesheet
+// actually take effect.
+
+namespace mdv {
+
+// Convert GFM-flavored markdown to HTML. Output is a fragment (no
+// <html>/<head>/<body> wrappers) suitable for QTextDocument::setHtml.
+QString markdownToHtml(const QString &markdown);
+
+}  // namespace mdv

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -6,7 +6,6 @@
 #include <QFormLayout>
 #include <QGroupBox>
 #include <QHBoxLayout>
-#include <QLabel>
 #include <QPushButton>
 #include <QSettings>
 #include <QSpinBox>
@@ -49,14 +48,6 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) : QDialog(parent) {
   m_monoFont = new QFontComboBox(fontsGroup);
   m_monoFont->setFontFilters(QFontComboBox::MonospacedFonts);
   fontsLayout->addRow(tr("Mono:"), m_monoFont);
-
-  // Note: mono size is intentionally absent — see header comment.
-  auto *hint = new QLabel(
-      tr("<small>Mono size tracks prose size (0.92em). Ctrl+wheel zooms "
-         "both together.</small>"),
-      fontsGroup);
-  hint->setWordWrap(true);
-  fontsLayout->addRow(QString(), hint);
 
   root->addWidget(fontsGroup);
   root->addStretch();

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -64,10 +64,13 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) : QDialog(parent) {
           &PreferencesDialog::onAccepted);
   connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
-  loadFromSettings();
+  reload();
 }
 
-void PreferencesDialog::loadFromSettings() {
+void PreferencesDialog::reload() {
+  // Called from the constructor and by MainWindow::onPreferences before
+  // each exec(). Idempotent — pulls every widget back to the persisted
+  // value so cancelled edits don't leak into the next opening.
   QSettings s;
 
   const QString theme =

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -1,0 +1,119 @@
+#include "PreferencesDialog.h"
+
+#include <QComboBox>
+#include <QDialogButtonBox>
+#include <QFontComboBox>
+#include <QFormLayout>
+#include <QGroupBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QSettings>
+#include <QSpinBox>
+#include <QVBoxLayout>
+
+#include "ContentTheme.h"
+
+PreferencesDialog::PreferencesDialog(QWidget *parent) : QDialog(parent) {
+  setWindowTitle(tr("Preferences"));
+  resize(440, 280);
+
+  auto *root = new QVBoxLayout(this);
+
+  // === Theme ===
+  auto *themeGroup = new QGroupBox(tr("Theme"), this);
+  auto *themeLayout = new QFormLayout(themeGroup);
+  m_themeCombo = new QComboBox(themeGroup);
+  // Show the human-readable theme name, but store the id (filename
+  // stem) as userData so QSettings persists the unambiguous handle.
+  for (const QString &id : ContentTheme::availableThemes()) {
+    m_themeCombo->addItem(ContentTheme::displayNameForBundled(id), id);
+  }
+  themeLayout->addRow(tr("Content theme:"), m_themeCombo);
+  root->addWidget(themeGroup);
+
+  // === Fonts ===
+  auto *fontsGroup = new QGroupBox(tr("Fonts"), this);
+  auto *fontsLayout = new QFormLayout(fontsGroup);
+
+  m_proseFont = new QFontComboBox(fontsGroup);
+  m_proseFont->setFontFilters(QFontComboBox::ProportionalFonts);
+  m_proseSize = new QSpinBox(fontsGroup);
+  m_proseSize->setRange(8, 48);
+  m_proseSize->setSuffix(tr(" pt"));
+  auto *proseRow = new QHBoxLayout;
+  proseRow->addWidget(m_proseFont, /*stretch=*/1);
+  proseRow->addWidget(m_proseSize);
+  fontsLayout->addRow(tr("Prose:"), proseRow);
+
+  m_monoFont = new QFontComboBox(fontsGroup);
+  m_monoFont->setFontFilters(QFontComboBox::MonospacedFonts);
+  fontsLayout->addRow(tr("Mono:"), m_monoFont);
+
+  // Note: mono size is intentionally absent — see header comment.
+  auto *hint = new QLabel(
+      tr("<small>Mono size tracks prose size (0.92em). Ctrl+wheel zooms "
+         "both together.</small>"),
+      fontsGroup);
+  hint->setWordWrap(true);
+  fontsLayout->addRow(QString(), hint);
+
+  root->addWidget(fontsGroup);
+  root->addStretch();
+
+  // === Buttons ===
+  auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok |
+                                       QDialogButtonBox::Apply |
+                                       QDialogButtonBox::Cancel);
+  root->addWidget(buttons);
+
+  connect(buttons->button(QDialogButtonBox::Apply), &QPushButton::clicked,
+          this, &PreferencesDialog::onApply);
+  connect(buttons, &QDialogButtonBox::accepted, this,
+          &PreferencesDialog::onAccepted);
+  connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+  loadFromSettings();
+}
+
+void PreferencesDialog::loadFromSettings() {
+  QSettings s;
+
+  const QString theme =
+      s.value(QStringLiteral("theme/content"), QStringLiteral("blackboard"))
+          .toString();
+  if (const int idx = m_themeCombo->findData(theme); idx >= 0) {
+    m_themeCombo->setCurrentIndex(idx);
+  }
+
+  const QString proseFamily = s.value(QStringLiteral("fonts/prose")).toString();
+  if (!proseFamily.isEmpty()) m_proseFont->setCurrentFont(QFont(proseFamily));
+
+  m_proseSize->setValue(
+      s.value(QStringLiteral("fonts/prose.size"), 14).toInt());
+
+  const QString monoFamily = s.value(QStringLiteral("fonts/mono")).toString();
+  if (!monoFamily.isEmpty()) m_monoFont->setCurrentFont(QFont(monoFamily));
+}
+
+void PreferencesDialog::saveToSettings() {
+  QSettings s;
+  s.setValue(QStringLiteral("theme/content"),
+             m_themeCombo->currentData().toString());
+  s.setValue(QStringLiteral("fonts/prose"),
+             m_proseFont->currentFont().family());
+  s.setValue(QStringLiteral("fonts/prose.size"), m_proseSize->value());
+  s.setValue(QStringLiteral("fonts/mono"),
+             m_monoFont->currentFont().family());
+}
+
+void PreferencesDialog::onApply() {
+  saveToSettings();
+  emit preferencesApplied();
+}
+
+void PreferencesDialog::onAccepted() {
+  saveToSettings();
+  emit preferencesApplied();
+  accept();
+}

--- a/src/PreferencesDialog.h
+++ b/src/PreferencesDialog.h
@@ -20,6 +20,12 @@ class PreferencesDialog : public QDialog {
 public:
   explicit PreferencesDialog(QWidget *parent = nullptr);
 
+  // Re-populate the widgets from QSettings. Called by MainWindow before
+  // each exec() so the dialog always opens reflecting the persisted
+  // state — Cancel discards in-flight edits, no stale values survive
+  // into the next opening.
+  void reload();
+
 signals:
   // Emitted after the user clicks Apply or OK and the new values have
   // been persisted to QSettings. MainWindow listens to this and
@@ -31,7 +37,6 @@ private slots:
   void onAccepted();
 
 private:
-  void loadFromSettings();
   void saveToSettings();
 
   QComboBox *m_themeCombo = nullptr;

--- a/src/PreferencesDialog.h
+++ b/src/PreferencesDialog.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <QDialog>
+
+class QComboBox;
+class QFontComboBox;
+class QSpinBox;
+
+// Modal dialog accessed via File → Preferences (Ctrl+,). Owns the user
+// choices that are not "structural": the active content theme, the
+// prose / mono font families, and the prose font size.
+//
+// Mono size is intentionally not exposed: the stylesheet sets it
+// relatively (0.92em) so that Ctrl+wheel zoom scales prose and code
+// together. If a future toolbar gets explicit size presets, they can
+// scale the same single "prose size" setting.
+class PreferencesDialog : public QDialog {
+  Q_OBJECT
+
+public:
+  explicit PreferencesDialog(QWidget *parent = nullptr);
+
+signals:
+  // Emitted after the user clicks Apply or OK and the new values have
+  // been persisted to QSettings. MainWindow listens to this and
+  // refreshes every open DocumentView.
+  void preferencesApplied();
+
+private slots:
+  void onApply();
+  void onAccepted();
+
+private:
+  void loadFromSettings();
+  void saveToSettings();
+
+  QComboBox *m_themeCombo = nullptr;
+  QFontComboBox *m_proseFont = nullptr;
+  QSpinBox *m_proseSize = nullptr;
+  QFontComboBox *m_monoFont = nullptr;
+};


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires in md4c as the Markdown renderer (replacing `QTextDocument::setMarkdown`, which bakes in character formats that override CSS), adds a JSON-driven content-theme system with a QSS template, introduces a Preferences dialog for theme and font settings, and extends drag-and-drop to accept OS file drops in addition to internal tab drags.

- **md4c integration** (`Markdown.cpp`, `DocumentView.cpp`): `markdownToHtml()` now handles `md_html` failures with a plain-text fallback, and `DocumentView` applies theme CSS via `setDefaultStyleSheet` + `setDefaultFont` + palette rather than relying on Qt's own markdown importer.
- **Content theming** (`ContentTheme.cpp/h`, theme JSONs, QSS template): `ContentTheme::reload()` falls back to the bundled \"blackboard\" theme on load failure and logs a warning; `#RRGGBBAA` colors are correctly rotated to Qt's `#AARRGGBB` order.
- **Preferences dialog** (`PreferencesDialog.cpp/h`): settings keys are consistent across `saveToSettings`, `reload`, `DocumentView::applyDocumentFont`, and `ContentTheme::fontValue`; the dialog is reset via `reload()` before each `exec()` so cancelled edits don't survive.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — no correctness defects found in the new rendering pipeline, theming system, or preferences flow.

The md4c integration correctly handles parse failures, the theme reload fallback is in place with a warning, and all QSettings keys are consistent across the three components that read and write them. The only finding is a minor API-surface concern in DocumentView.h.

No files require special attention.

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/ContentTheme.cpp`, line 513-527 ([link](https://github.com/gesslar/mdv.qt/blob/aae17169a1cd31e3e91fd928b59938a0b813c3ed/src/ContentTheme.cpp#L513-L527)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Settings key mismatch for compound font keys**

   `replace('.', '/')` converts `"fonts.prose.size"` to `"fonts/prose/size"` (group `fonts`, subgroup `prose`, key `size`), but `PreferencesDialog::saveToSettings` and `DocumentView::applyDocumentFont` write to `"fonts/prose.size"` (group `fonts`, key `prose.size` — the dot is part of the key name, not a group separator). Any template placeholder like `@{fonts.prose.size}` would silently fall back to the hardcoded default instead of reading the user's persisted value. The comment notes this path exists for future use, so the mismatch would surface invisibly the moment such a placeholder is added.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2FContentTheme.cpp%0ALine%3A%20513-527%0A%0AComment%3A%0A**Settings%20key%20mismatch%20for%20compound%20font%20keys**%0A%0A%60replace%28'.'%2C%20'%2F'%29%60%20converts%20%60%22fonts.prose.size%22%60%20to%20%60%22fonts%2Fprose%2Fsize%22%60%20%28group%20%60fonts%60%2C%20subgroup%20%60prose%60%2C%20key%20%60size%60%29%2C%20but%20%60PreferencesDialog%3A%3AsaveToSettings%60%20and%20%60DocumentView%3A%3AapplyDocumentFont%60%20write%20to%20%60%22fonts%2Fprose.size%22%60%20%28group%20%60fonts%60%2C%20key%20%60prose.size%60%20%E2%80%94%20the%20dot%20is%20part%20of%20the%20key%20name%2C%20not%20a%20group%20separator%29.%20Any%20template%20placeholder%20like%20%60%40%7Bfonts.prose.size%7D%60%20would%20silently%20fall%20back%20to%20the%20hardcoded%20default%20instead%20of%20reading%20the%20user's%20persisted%20value.%20The%20comment%20notes%20this%20path%20exists%20for%20future%20use%2C%20so%20the%20mismatch%20would%20surface%20invisibly%20the%20moment%20such%20a%20placeholder%20is%20added.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gesslar%2Fmdv.qt&pr=1&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2FDocumentView.h%3A16-31%0A%60applyDocumentFont%28%29%60%20and%20%60applyDocumentPalette%28%29%60%20are%20only%20ever%20called%20from%20%60DocumentView%60's%20own%20constructor%20and%20%60refresh%28%29%60%20%E2%80%94%20no%20external%20caller%20exists%20in%20the%20codebase.%20Declaring%20them%20%60public%60%20widens%20the%20class's%20API%20surface%20unnecessarily%20and%20could%20invite%20callers%20that%20skip%20the%20companion%20step%20%28e.g.%2C%20calling%20%60applyDocumentFont%60%20without%20%60applyDocumentPalette%60%29%2C%20leading%20to%20a%20partially-updated%20document%20state.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20Re-apply%20the%20active%20content%20theme's%20stylesheet%20and%20re-render%20the%0A%20%20%2F%2F%20current%20file's%20HTML%20so%20the%20new%20styles%20take%20effect.%20Used%20when%20the%0A%20%20%2F%2F%20Preferences%20dialog%20changes%20theme%20or%20fonts.%20No-op%20if%20no%20file%20is%20loaded.%0A%20%20void%20refresh%28%29%3B%0A%0A%20%20%2F%2F%20Canonical%20%28symlink-resolved%29%20absolute%20path%2C%20or%20empty%20if%20no%20file%20is%20loaded.%0A%60%60%60%0A%0A&repo=gesslar%2Fmdv.qt&pr=1&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (6): Last reviewed commit: ["update"](https://github.com/gesslar/mdv.qt/commit/05e3edf870bae2cecd4c54354f9f6148e50b8e91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33597988)</sub>

<!-- /greptile_comment -->