### PR TITLE
few bits of setting up for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,29 @@ find_package(Qt6 6.5 REQUIRED COMPONENTS Widgets)
 # rather than QTextDocument::setMarkdown because the latter bakes explicit
 # character formats into the document that override CSS supplied via
 # setDefaultStyleSheet.
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(MD4C_HTML REQUIRED IMPORTED_TARGET md4c-html)
+#
+# Fetched and built in-tree so Windows/macOS/Linux all share the same
+# dependency story without a system pkg-config install.
+include(FetchContent)
+# Linkage choice per platform matches how we ship:
+#   Windows  — static, so the installer ships a single self-contained mdv.exe.
+#   Linux/mac — shared, so .deb/.rpm/Homebrew can swap our in-tree build for
+#               a system md4c at package time without changing link semantics.
+# Cache + FORCE because md4c's CMakeLists calls option(BUILD_SHARED_LIBS …)
+# under CMP0077 OLD, which would otherwise clobber a plain set().
+if(WIN32)
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries" FORCE)
+else()
+    set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries" FORCE)
+endif()
+set(BUILD_MD2HTML_EXECUTABLE OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    md4c
+    GIT_REPOSITORY https://github.com/mity/md4c.git
+    GIT_TAG release-0.5.3
+    GIT_SHALLOW TRUE
+)
+FetchContent_MakeAvailable(md4c)
 
 qt_standard_project_setup()
 
@@ -52,7 +73,7 @@ qt_add_executable(mdv
     resources/resources.qrc
 )
 
-target_link_libraries(mdv PRIVATE Qt6::Widgets PkgConfig::MD4C_HTML)
+target_link_libraries(mdv PRIVATE Qt6::Widgets md4c-html)
 
 target_include_directories(mdv PRIVATE src)
 

--- a/qt.bash
+++ b/qt.bash
@@ -12,8 +12,9 @@ PACKAGES=(
     ninja-build        # faster generator than make for CMake
     gdb                # debugger Qt Creator drives
     clang-tools-extra  # clangd, for code model + completion
-    md4c-devel         # markdown → HTML (CommonMark + GFM)
 )
+# md4c is fetched and built in-tree by CMake (see CMakeLists.txt), so no
+# md4c-devel package is required for development.
 
 if ! command -v dnf >/dev/null 2>&1; then
     echo "error: this script expects dnf (Fedora). Adapt for your distro." >&2


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the md4c dependency from a system-installed pkg-config package to an in-tree FetchContent build, making the project self-contained on Windows, macOS, and Linux alike.

- **CMakeLists.txt**: `find_package(PkgConfig)` + `pkg_check_modules` are replaced with `FetchContent_Declare`/`FetchContent_MakeAvailable` targeting md4c `release-0.5.3`; a platform guard sets `BUILD_SHARED_LIBS` OFF on Windows (for a single-binary installer) and ON elsewhere (to allow package managers to substitute a system md4c).
- **qt.bash**: `md4c-devel` is dropped from the Fedora install list, with a comment pointing to `CMakeLists.txt` as the new source of the dependency.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the dependency wiring is correct for the current project structure and the change is well-documented.

The FetchContent wiring is correct and the target name md4c-html matches what md4c's own CMakeLists exports. The one thing worth watching is that BUILD_SHARED_LIBS is set globally with FORCE for the entire build tree — currently harmless since mdv is an executable and md4c is the only fetched library, but it would silently affect any future add_library call or additional FetchContent dependency added to the project.

CMakeLists.txt — specifically the global BUILD_SHARED_LIBS FORCE block around lines 37–41.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACMakeLists.txt%3A37-41%0A**Global%20%60BUILD_SHARED_LIBS%60%20side%20effect**%0A%0A%60BUILD_SHARED_LIBS%60%20is%20a%20project-wide%20CMake%20variable%20%E2%80%94%20setting%20it%20with%20%60FORCE%60%20before%20%60FetchContent_MakeAvailable%60%20affects%20every%20%60add_library%28%29%60%20call%20in%20the%20entire%20build%20tree%2C%20not%20just%20md4c.%20Right%20now%20this%20is%20harmless%20because%20%60mdv%60%20is%20an%20executable%20and%20md4c%20is%20the%20only%20fetched%20dependency%2C%20but%20any%20future%20%60add_library%28some_util%20...%29%60%20call%20or%20additional%20FetchContent%20dependency%20would%20silently%20inherit%20the%20platform%20linkage%20policy.%20A%20safer%20pattern%20is%20to%20save%20and%20restore%20the%20variable%20around%20%60FetchContent_MakeAvailable%60%3A%20save%20the%20old%20value%20to%20a%20temp%20variable%20before%20the%20%60if%28WIN32%29%60%20block%2C%20call%20%60FetchContent_MakeAvailable%28md4c%29%60%2C%20then%20restore%20it.%20This%20keeps%20the%20workaround%20scoped%20to%20md4c%20alone.%0A%0A&repo=gesslar%2Fmdv.qt&pr=2&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["few bits of setting up for Windows"](https://github.com/gesslar/mdv.qt/commit/bf6300bbacff4a0ab431ec0bb9f840a84ac85a00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33604366)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->