### PR TITLE
some fixie fixes

### DIFF
--- a/THEMING.md
+++ b/THEMING.md
@@ -62,6 +62,12 @@ translucent borders and backgrounds.
 Keep `syntax.*` token colors **solid** (6-digit, no alpha) — they color text,
 where transparency isn't meaningful.
 
+Block-fill backgrounds (`code.background`, `blockquote.background`,
+`table.header.background`) may use alpha, but they're flattened onto
+`text.background` at load and render **opaque** — the document engine can't
+paint a translucent block fill without faint per-line seams. You author the
+tint normally; it just resolves to the exact color it would show over the page.
+
 ## Spacing keys
 
 | Key            | Applies to                                  |
@@ -162,3 +168,7 @@ MD040).
 
 See [`examples/`](examples/) for documents that exercise every element and
 language — open them and switch themes to check your work.
+
+Curious how these keys become the rendered stylesheet (placeholder resolution,
+the alpha handling, font wiring)? That's developer internals in
+[`docs/templating.md`](docs/templating.md).

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1,0 +1,94 @@
+# Content stylesheet templating
+
+How a rendered Markdown document gets its styling. This is developer-facing
+internals; for *authoring* a theme, see [`../THEMING.md`](../THEMING.md).
+
+## Three channels (and why)
+
+No single Qt mechanism styles the whole document, so the styling is assembled
+across three, each chosen to work around a QTextDocument/QTextBrowser quirk:
+
+1. **Element CSS** → `QTextDocument::setDefaultStyleSheet(ContentTheme::qss())`.
+   Headings, code, tables, lists, blockquotes, rules, links. Persists across
+   subsequent `setHtml()` calls.
+2. **Prose font** → `QTextDocument::setDefaultFont()`. A CSS `body { font-family }`
+   doesn't propagate: the md4c HTML fragment has no real `<body>` to bind to, and
+   Qt routes the document font through the default `QFont`, not CSS. Set as a
+   **point** size so `Ctrl`+wheel zoom (which works in points) scales it.
+3. **Page background + default text color** → `QPalette::Base` / `QPalette::Text`
+   on the browser. `body { background-color }` doesn't paint the widget viewport;
+   QTextBrowser paints it from the palette.
+
+(Code-block token colors are a fourth, separate path — inline `<span style>`
+emitted by the KSyntaxHighlighting pass; see `src/Highlighter.cpp`.)
+
+All three are applied in `DocumentView`'s constructor and re-applied in
+`DocumentView::refresh()`, which Preferences calls after a theme/font change.
+
+## The template
+
+`resources/content/content.qss.template` holds the **structural** CSS — border
+styles, padding shapes, radii, `white-space`, relative font sizing — with
+`@{key}` placeholders for the tunable values. Structure is a decision and lives
+here; colors/spacing/fonts are values and come from the theme or settings.
+
+## Placeholder resolution
+
+`ContentTheme::qss()` substitutes every `@{key}` via `resolveKey()`, which routes
+by prefix:
+
+| Prefix       | Source                              | Notes |
+| ------------ | ----------------------------------- | ----- |
+| `fonts.*`    | `QSettings` (`fontValue()`)         | Set in Preferences |
+| `spacing.*`  | theme JSON `spacing` section        | CSS length strings |
+| *(anything else)* | theme JSON `colors` section    | run through `coerceColor` / `compositeOver` |
+
+### `fonts.*` → QSettings
+
+`fontValue()` converts only the **first** dot to a QSettings group separator, so
+`fonts.prose.size` maps to `fonts/prose.size` (group `fonts`, key `prose.size`)
+— matching where `PreferencesDialog` writes it. A `.size` value stored as a bare
+integer gets `px` appended. Fallbacks: `sans-serif` / `monospace` / `14px`.
+
+Note the template sizes monospace as `font-size: 0.92em` (relative), so
+`Ctrl`+wheel zoom scales code alongside prose.
+
+### `coerceColor` — the 8-digit hex quirk
+
+Qt's stylesheet parser reads 8-digit hex as `#AARRGGBB` (Android order), not
+CSS3's `#RRGGBBAA`. So `coerceColor` rotates the trailing alpha byte to the
+front, letting authors write standard CSS (`#5d88af66`). 3/6-digit hex, `rgba()`,
+and named colors pass through untouched.
+
+### `compositeOver` — block-background flattening
+
+QTextDocument fills a block's background **per text-line**, and adjacent line
+rectangles overlap by a sub-pixel — so a *translucent* block fill compounds at
+the seams into faint horizontal lines. To avoid that, the block-fill background
+keys are pre-composited onto the page color and resolve **opaque**:
+
+- `code.background`
+- `blockquote.background`
+- `table.header.background`
+
+(see the `blockBackgrounds` set in `ContentTheme::resolveKey`). The composite is
+exact — it's the color the translucent tint would show over `text.background` —
+so authors keep writing natural translucent tints. Opaque inputs pass through
+unchanged.
+
+> Because `text.background` is the composite backdrop **and** is consumed raw via
+> `QPalette` in `DocumentView::applyDocumentPalette()`, it should stay opaque.
+
+## Adding a style slot
+
+1. Add the CSS rule to `content.qss.template`, using `@{your.key}`.
+2. Add `your.key` to the theme JSONs (`colors` or `spacing`).
+3. If it's a **multi-line block background**, add the key to the
+   `blockBackgrounds` set in `src/ContentTheme.cpp` so it gets flattened.
+4. Document the new slot in `THEMING.md` (the author-facing tables).
+
+## Where the pieces live
+
+- `resources/content/content.qss.template` — structural CSS + `@{…}` slots
+- `src/ContentTheme.{h,cpp}` — `resolveKey`, `coerceColor`, `compositeOver`, `qss()`
+- `src/DocumentView.cpp` — applies the three channels (stylesheet / font / palette)

--- a/src/ContentTheme.cpp
+++ b/src/ContentTheme.cpp
@@ -1,5 +1,6 @@
 #include "ContentTheme.h"
 
+#include <QColor>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
@@ -7,6 +8,7 @@
 #include <QJsonObject>
 #include <QJsonValue>
 #include <QRegularExpression>
+#include <QSet>
 #include <QSettings>
 #include <QStringList>
 
@@ -40,6 +42,28 @@ QString coerceColor(const QString &value) {
   const auto m = re.match(value);
   if (!m.hasMatch()) return value;
   return QStringLiteral("#%1%2").arg(m.captured(2), m.captured(1));
+}
+
+// Flatten a (possibly translucent) color onto an opaque backdrop, returning an
+// opaque "#rrggbb". QTextDocument fills a block background per text-line, and a
+// translucent fill compounds at the line overlaps into faint seams — so block
+// backgrounds are pre-composited over the page color rather than left with
+// alpha. Authors still write the natural tint; this is the exact color it would
+// render as on the page.
+QString compositeOver(const QString &fg, const QString &bg) {
+  const QColor top(coerceColor(fg));
+  if (!top.isValid()) return fg;
+
+  const qreal a = top.alphaF();
+  const QColor base(coerceColor(bg));
+  if (a >= 1.0 || !base.isValid()) return top.name(QColor::HexRgb);
+
+  const auto mix = [a](int t, int b) {
+    return qRound(b * (1.0 - a) + t * a);
+  };
+  return QColor(mix(top.red(), base.red()), mix(top.green(), base.green()),
+                mix(top.blue(), base.blue()))
+      .name(QColor::HexRgb);
 }
 
 }  // namespace
@@ -115,6 +139,19 @@ QString ContentTheme::resolveKey(const QString &key) const {
 
   if (key.startsWith(QStringLiteral("spacing."))) {
     return m_spacing.value(key.mid(8));  // strip "spacing."
+  }
+
+  // Block-fill backgrounds get flattened onto the page color: the document
+  // engine paints them per text-line and a translucent fill seams at the
+  // overlaps. Authors can still use alpha here; it just renders opaque.
+  static const QSet<QString> blockBackgrounds = {
+      QStringLiteral("code.background"),
+      QStringLiteral("blockquote.background"),
+      QStringLiteral("table.header.background"),
+  };
+  if (blockBackgrounds.contains(key)) {
+    return compositeOver(m_colors.value(key),
+                         m_colors.value(QStringLiteral("text.background")));
   }
 
   // Anything else is a color key. Bare ("text.foreground") in the

--- a/src/ContentTheme.cpp
+++ b/src/ContentTheme.cpp
@@ -55,8 +55,19 @@ QString compositeOver(const QString &fg, const QString &bg) {
   if (!top.isValid()) return fg;
 
   const qreal a = top.alphaF();
+  if (a >= 1.0) return top.name(QColor::HexRgb);  // already opaque
+
   const QColor base(coerceColor(bg));
-  if (a >= 1.0 || !base.isValid()) return top.name(QColor::HexRgb);
+  if (!base.isValid()) {
+    // No backdrop to flatten onto (the theme omitted text.background). Keep the
+    // author's translucent tint — the correct hue, even if it can't dodge the
+    // per-line seam — rather than silently dropping alpha to a saturated shade.
+    // coerceColor (not raw fg) so Qt still parses the #RRGGBBAA ordering right.
+    qWarning("ContentTheme: block background '%s' is translucent but "
+             "text.background is missing; leaving it translucent",
+             qPrintable(fg));
+    return coerceColor(fg);
+  }
 
   const auto mix = [a](int t, int b) {
     return qRound(b * (1.0 - a) + t * a);

--- a/src/DocumentView.cpp
+++ b/src/DocumentView.cpp
@@ -2,6 +2,8 @@
 
 #include <QAbstractTextDocumentLayout>
 #include <QColor>
+#include <QDesktopServices>
+#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include <QFont>
@@ -15,6 +17,7 @@
 #include <QTextCursor>
 #include <QTextStream>
 #include <QTimer>
+#include <QUrl>
 #include <QVBoxLayout>
 
 #include "ContentTheme.h"
@@ -26,7 +29,12 @@ DocumentView::DocumentView(QWidget *parent) : QWidget(parent) {
   layout->setContentsMargins(0, 0, 0, 0);
 
   m_browser = new QTextBrowser(this);
-  m_browser->setOpenExternalLinks(true);
+  // Handle every link click ourselves. With openLinks left on, QTextBrowser
+  // navigates the view onto the target (setSource) — which for a local file
+  // wipes the rendered document. onAnchorClicked() classifies instead.
+  m_browser->setOpenLinks(false);
+  connect(m_browser, &QTextBrowser::anchorClicked, this,
+          &DocumentView::onAnchorClicked);
   m_browser->setContextMenuPolicy(Qt::CustomContextMenu);
   // Disable QTextBrowser's own drop handling so file URL drops bubble
   // up to the EditorPane (which interprets them as "open this file")
@@ -141,6 +149,37 @@ void DocumentView::applyDocumentPalette() {
   if (!bg.isEmpty()) p.setColor(QPalette::Base, QColor(bg));
   if (!fg.isEmpty()) p.setColor(QPalette::Text, QColor(fg));
   m_browser->setPalette(p);
+}
+
+void DocumentView::onAnchorClicked(const QUrl &url) {
+  const QString scheme = url.scheme();
+
+  // External: any non-file scheme (http/https/mailto/…) → system handler.
+  if (!scheme.isEmpty() && scheme != QLatin1String("file")) {
+    QDesktopServices::openUrl(url);
+    return;
+  }
+
+  // In-document anchor (#heading). Heading ids aren't generated yet (that
+  // lands with the TOC work), so this currently finds nothing and no-ops —
+  // wired here so it lights up once the ids exist.
+  if (url.path().isEmpty() && url.hasFragment()) {
+    m_browser->scrollToAnchor(url.fragment());
+    return;
+  }
+
+  // Local file: resolve relative to this document's directory and open it as
+  // a new tab. Any #fragment is dropped — we just open the target file.
+  const QString rawPath =
+      (scheme == QLatin1String("file")) ? url.toLocalFile() : url.path();
+  if (rawPath.isEmpty()) return;
+
+  const QString base = QFileInfo(m_filePath).absolutePath();
+  const QString resolved =
+      QDir::isAbsolutePath(rawPath)
+          ? QDir::cleanPath(rawPath)
+          : QDir::cleanPath(base + QLatin1Char('/') + rawPath);
+  emit openFileRequested(resolved);
 }
 
 int DocumentView::topAnchor() const {

--- a/src/DocumentView.h
+++ b/src/DocumentView.h
@@ -4,6 +4,7 @@
 #include <QWidget>
 
 class QTextBrowser;
+class QUrl;
 
 class DocumentView : public QWidget {
   Q_OBJECT
@@ -59,8 +60,13 @@ public:
 signals:
   void fileLoaded(const QString &canonicalPath);
 
+  // A local-file link was clicked. The path is resolved (absolute, cleaned)
+  // against this document's directory; the owner opens it as a new tab.
+  void openFileRequested(const QString &path);
+
 private slots:
   void onContextMenuRequested(const QPoint &pos);
+  void onAnchorClicked(const QUrl &url);
 
 private:
   QTextBrowser *m_browser = nullptr;

--- a/src/EditorArea.cpp
+++ b/src/EditorArea.cpp
@@ -224,6 +224,8 @@ void EditorArea::registerPane(EditorPane *pane) {
           &EditorArea::onPaneCurrentDocumentChanged);
   connect(pane, &EditorPane::tabClosed, this, &EditorArea::onTabClosed);
   connect(pane, &EditorPane::filesDropped, this, &EditorArea::filesDropped);
+  connect(pane, &EditorPane::openFileRequested, this,
+          &EditorArea::openFileRequested);
 }
 
 void EditorArea::onTabClosed(const QString &filePath) {

--- a/src/EditorArea.h
+++ b/src/EditorArea.h
@@ -56,6 +56,10 @@ signals:
   // route through their normal openFile path.
   void filesDropped(const QStringList &paths);
 
+  // Re-emission of a pane's openFileRequested — a local-file link was
+  // clicked; subscribers open it through their normal openFile path.
+  void openFileRequested(const QString &path);
+
 private slots:
   void onPaneActivated();
   void onPaneEmpty();

--- a/src/EditorPane.cpp
+++ b/src/EditorPane.cpp
@@ -92,6 +92,11 @@ EditorPane::EditorPane(QWidget *parent) : QTabWidget(parent) {
 }
 
 int EditorPane::addDocument(DocumentView *doc) {
+  // Relay link-driven opens up toward the window. UniqueConnection because a
+  // tab can pass through addDocument again when dragged between panes.
+  connect(doc, &DocumentView::openFileRequested, this,
+          &EditorPane::openFileRequested, Qt::UniqueConnection);
+
   const int idx = addTab(doc, doc->displayName());
   setTabToolTip(idx, doc->filePath());
   setCurrentIndex(idx);

--- a/src/EditorPane.h
+++ b/src/EditorPane.h
@@ -66,6 +66,10 @@ signals:
   // from the OS. The pane has already focused itself before emitting.
   void filesDropped(const QStringList &paths);
 
+  // Re-emission of a contained document's openFileRequested — a local-file
+  // link was clicked and should open as a new tab.
+  void openFileRequested(const QString &path);
+
 protected:
   void focusInEvent(QFocusEvent *e) override;
   void mousePressEvent(QMouseEvent *e) override;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -36,6 +36,10 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
           [this](const QStringList &paths) {
             for (const QString &p : paths) openFile(p);
           });
+  // A local-file link clicked in a document opens as a new tab (and lands in
+  // Recent Files) through the same path as any other open.
+  connect(m_area, &EditorArea::openFileRequested, this,
+          [this](const QString &path) { openFile(path); });
 
   // Catch-all for drops that miss the EditorArea (menubar, status bar,
   // any chrome). Drops anywhere on the window get routed to the

--- a/src/Markdown.cpp
+++ b/src/Markdown.cpp
@@ -49,18 +49,27 @@ QString highlightCodeBlocks(const QString &html) {
     out.append(QStringView(html).sliced(last, m.capturedStart() - last));
     last = m.capturedEnd();
 
+    // md4c terminates code-block content with a newline, which renders as a
+    // trailing blank line inside the <pre>; drop exactly one.
+    QString inner = m.captured(2);
+    if (inner.endsWith(QLatin1Char('\n'))) inner.chop(1);
+
     // md4c puts the whole info string in the class; the language is its first
     // whitespace-delimited token.
-    const QString info = m.captured(1);
-    const QString lang = info.split(QLatin1Char(' '), Qt::SkipEmptyParts).value(0);
+    const QString lang =
+        m.captured(1).split(QLatin1Char(' '), Qt::SkipEmptyParts).value(0);
     if (lang.isEmpty()) {
-      out.append(m.captured(0));  // leave unlabeled blocks untouched
+      // Unlabeled / unknown blocks aren't highlighted; re-emit the already-
+      // escaped content with the trailing newline trimmed.
+      out.append(QStringLiteral("<pre><code>"));
+      out.append(inner);
+      out.append(QStringLiteral("</code></pre>"));
       continue;
     }
 
     out.append(QStringLiteral("<pre><code class=\"language-%1\">")
                    .arg(lang.toHtmlEscaped()));
-    out.append(highlightCode(unescapeHtml(m.captured(2)), lang));
+    out.append(highlightCode(unescapeHtml(inner), lang));
     out.append(QStringLiteral("</code></pre>"));
   }
   out.append(QStringView(html).sliced(last));


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes several focused fixes: it replaces the simplistic `setOpenExternalLinks(true)` with a custom `onAnchorClicked` handler that properly classifies link clicks (external, in-document fragment, local file), propagates a new `openFileRequested` signal up the widget hierarchy so local-file links open as tabs, and pre-composites translucent block-fill backgrounds over the page color to avoid QTextDocument's per-line seam artifact. A separate fix removes the spurious trailing blank line that md4c emits inside `<pre>` blocks.

- **Link routing overhaul** (`DocumentView`, `EditorPane`, `EditorArea`, `MainWindow`): `setOpenLinks(false)` + `onAnchorClicked` replaces `setOpenExternalLinks`, preventing QTextBrowser from wiping the rendered document on local-file clicks; a new `openFileRequested` signal chain lets those clicks open a new tab through the standard `openFile` path.
- **Block-background compositing** (`ContentTheme.cpp`): `compositeOver()` flattens translucent `code.background`/`blockquote.background`/`table.header.background` onto `text.background` at stylesheet-generation time, avoiding the sub-pixel seam artifact; missing backdrop now emits a `qWarning` and preserves the translucent color rather than silently stripping alpha.
- **Trailing-newline fix** (`Markdown.cpp`): md4c's extra trailing `\n` in code-block content is chomped before re-emission, removing the blank line that previously appeared at the bottom of every rendered code block.

<h3>Confidence Score: 5/5</h3>

The changes are well-scoped and safe to merge; each fix addresses a concrete rendering or navigation defect without touching any shared state or persistence paths.

All three change areas (link routing, block-background compositing, trailing-newline trim) are isolated and correct. The signal chain uses Qt::UniqueConnection to guard against duplicate wiring on tab-drag, edge cases in path resolution fall back gracefully, and the compositing math is exact. No regressions were found.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["fix"](https://github.com/gesslar/mdv.qt/commit/1038e2ab4c5466936d414d349aa42285bee5a493) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33638725)</sub>

<!-- /greptile_comment -->