### PR TITLE
tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,39 +19,45 @@ endif()
 
 find_package(Qt6 6.5 REQUIRED COMPONENTS Widgets)
 
-# Code-block syntax highlighting. Taken from the system on Linux/macOS; on
-# Windows this will need to be bundled/built statically at packaging time
-# (mirroring the md4c strategy below). KSyntaxHighlighting tokenizes code and
-# we map its default styles onto the active content theme's syntax.* colors.
-find_package(KF6SyntaxHighlighting REQUIRED)
+# --- Non-Qt dependencies ------------------------------------------------------
+#
+# Acquisition rule for build-time deps: take them from the system package
+# manager wherever it has them (Linux/macOS), and only build in-tree where the
+# platform has no package (Windows md4c). Distribution linkage — which .so the
+# .deb pulls, which .dll the installer bundles — is a packaging concern handled
+# downstream, NOT here. DEVELOPMENT.md has the per-platform install steps.
 
 # md4c (CommonMark + GFM markdown parser). We use the C library directly
 # rather than QTextDocument::setMarkdown because the latter bakes explicit
 # character formats into the document that override CSS supplied via
 # setDefaultStyleSheet.
 #
-# Fetched and built in-tree so Windows/macOS/Linux all share the same
-# dependency story without a system pkg-config install.
-include(FetchContent)
-# Linkage choice per platform matches how we ship:
-#   Windows  — static, so the installer ships a single self-contained mdv.exe.
-#   Linux/mac — shared, so .deb/.rpm/Homebrew can swap our in-tree build for
-#               a system md4c at package time without changing link semantics.
-# Cache + FORCE because md4c's CMakeLists calls option(BUILD_SHARED_LIBS …)
-# under CMP0077 OLD, which would otherwise clobber a plain set().
+# The system package exports the namespaced imported target md4c::md4c-html;
+# FetchContent exports the plain target md4c-html. The ${MD4C} indirection
+# papers over that difference so the link line stays uniform.
 if(WIN32)
-    set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build shared libraries" FORCE)
+    # No dnf/brew/vcpkg-by-default for md4c here — fetch & build it just to dev.
+    include(FetchContent)
+    set(BUILD_MD2HTML_EXECUTABLE OFF CACHE BOOL "" FORCE)
+    FetchContent_Declare(
+        md4c
+        GIT_REPOSITORY https://github.com/mity/md4c.git
+        GIT_TAG release-0.5.3
+        GIT_SHALLOW TRUE
+    )
+    FetchContent_MakeAvailable(md4c)
+    set(MD4C md4c-html)
 else()
-    set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries" FORCE)
+    find_package(md4c REQUIRED)
+    set(MD4C md4c::md4c-html)
 endif()
-set(BUILD_MD2HTML_EXECUTABLE OFF CACHE BOOL "" FORCE)
-FetchContent_Declare(
-    md4c
-    GIT_REPOSITORY https://github.com/mity/md4c.git
-    GIT_TAG release-0.5.3
-    GIT_SHALLOW TRUE
-)
-FetchContent_MakeAvailable(md4c)
+
+# KSyntaxHighlighting — code-block tokenizer; we map its default styles onto
+# the active content theme's syntax.* colors. find_package resolves it on
+# every platform, but the Qt installer doesn't bundle KF6: on Windows install
+# it via KDE Craft and on macOS via MacPorts/Craft, then point CMake at it with
+# -DCMAKE_PREFIX_PATH=<prefix>. See DEVELOPMENT.md for the per-platform steps.
+find_package(KF6SyntaxHighlighting REQUIRED)
 
 qt_standard_project_setup()
 
@@ -80,7 +86,7 @@ qt_add_executable(mdv
     resources/resources.qrc
 )
 
-target_link_libraries(mdv PRIVATE Qt6::Widgets md4c-html KF6::SyntaxHighlighting)
+target_link_libraries(mdv PRIVATE Qt6::Widgets ${MD4C} KF6::SyntaxHighlighting)
 
 target_include_directories(mdv PRIVATE src)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,22 +3,25 @@
 ## Prerequisites
 
 - **Qt 6.5 or newer** (Widgets module)
+- **md4c** — CommonMark + GFM markdown parser
 - **KSyntaxHighlighting** (KDE Frameworks 6) — code-block syntax highlighting
 - **CMake 3.21 or newer**
 - **Ninja** (the build generator used here)
 - A C++20 compiler — GCC 11+, Clang 14+, MSVC 2022
 
-> md4c is fetched and built in-tree by CMake, so it needs no package.
-> KSyntaxHighlighting is taken from the system (Linux/macOS). Windows bundling
-> is planned but not yet wired, so Windows builds currently need KF6
-> SyntaxHighlighting provided to CMake yourself.
+> The rule for the two non-Qt deps: take them from the system package manager
+> wherever it has them. On Linux that's both (install with the commands below).
+> md4c has no package on Windows, so CMake fetches and builds it in-tree there —
+> nothing to install. KSyntaxHighlighting isn't carried by the Qt installer on
+> Windows or by Homebrew on macOS; install it via KDE Craft (or MacPorts) and
+> point CMake at it with `-DCMAKE_PREFIX_PATH`. The per-platform steps are below.
 
 ## Installing dependencies
 
 ### Fedora
 
 ```bash
-sudo dnf install qt6-qtbase-devel kf6-syntax-highlighting-devel cmake ninja-build gcc-c++
+sudo dnf install qt6-qtbase-devel md4c-devel kf6-syntax-highlighting-devel cmake ninja-build gcc-c++
 ```
 
 Add `qt-creator gdb clang-tools-extra` if you want the IDE and debugger.
@@ -26,7 +29,7 @@ Add `qt-creator gdb clang-tools-extra` if you want the IDE and debugger.
 ### Debian / Ubuntu
 
 ```bash
-sudo apt install qt6-base-dev libkf6syntaxhighlighting-dev cmake ninja-build g++
+sudo apt install qt6-base-dev libmd4c-dev libkf6syntaxhighlighting-dev cmake ninja-build g++
 # Optional IDE:
 sudo apt install qtcreator
 ```
@@ -34,7 +37,7 @@ sudo apt install qtcreator
 ### Arch
 
 ```bash
-sudo pacman -S qt6-base syntax-highlighting cmake ninja gcc qtcreator
+sudo pacman -S qt6-base md4c syntax-highlighting cmake ninja gcc qtcreator
 ```
 
 ### macOS
@@ -42,13 +45,13 @@ sudo pacman -S qt6-base syntax-highlighting cmake ninja gcc qtcreator
 The official **[Qt online installer](https://www.qt.io/download-qt-installer)** is the easiest path. Pick Qt 6.5+ with the Widgets module. Then:
 
 ```bash
-brew install cmake ninja
+brew install md4c cmake ninja
 ```
 
 Or via Homebrew end-to-end:
 
 ```bash
-brew install qt cmake ninja
+brew install qt md4c cmake ninja
 ```
 
 (Homebrew's `qt` is sometimes a release behind upstream — fine for this project, but verify with `qmake6 --version`.)
@@ -60,6 +63,23 @@ KSyntaxHighlighting (KDE Frameworks 6) isn't in Homebrew core; on macOS install 
 Install the official **[Qt online installer](https://www.qt.io/download-qt-installer)** and select Qt 6.5+ with **MSVC 2022 64-bit** (or MinGW if you prefer). The installer also bundles CMake, Ninja, and Qt Creator.
 
 If you'd rather use system tooling: install **Visual Studio 2022** (with the "Desktop development with C++" workload) and a standalone CMake.
+
+**md4c** has no Windows package, so CMake fetches and builds it in-tree — nothing to install.
+
+**KSyntaxHighlighting** isn't bundled by the Qt installer. Get it from **[KDE Craft](https://community.kde.org/Craft)**, KDE's build system for Windows (it pulls in extra-cmake-modules and the syntax/theme data for you):
+
+```powershell
+# In a Craft shell, after the one-time Craft setup:
+craft kf6-syntax-highlighting
+```
+
+Then point CMake at the Craft prefix when configuring:
+
+```powershell
+cmake -S . -B build -G Ninja -DCMAKE_PREFIX_PATH=C:/CraftRoot
+```
+
+(Use your actual `CraftRoot` path. The same `-DCMAKE_PREFIX_PATH` trick is how the macOS MacPorts/Craft install gets found.)
 
 ## Building
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors how the two non-Qt build dependencies are acquired: md4c is now fetched in-tree via `FetchContent` only on Windows, while Linux and macOS resolve it via the system package manager (`find_package`); a `${MD4C}` indirection variable handles the namespaced-vs-plain imported-target difference. `DEVELOPMENT.md` is updated to document the per-platform install steps for both `md4c` and `KSyntaxHighlighting`.

- `CMakeLists.txt`: splits the md4c acquisition path by platform, removes the global `BUILD_SHARED_LIBS` cache pin, and moves `find_package(KF6SyntaxHighlighting)` after the md4c block with an expanded comment.
- `DEVELOPMENT.md`: adds `md4c` to every Linux distro's install command, adds it to the macOS Homebrew steps, and adds a new Windows section with explicit KDE Craft commands for `KSyntaxHighlighting` and the required `-DCMAKE_PREFIX_PATH` flag.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the only gap is that Windows FetchContent no longer explicitly pins md4c to a static build, which only matters if BUILD_SHARED_LIBS is set to ON externally.

The refactor is clean and the documentation is thorough. The old code deliberately forced BUILD_SHARED_LIBS OFF with CACHE FORCE on Windows to guard against an existing cache value silently producing a shared md4c.dll the installed exe cannot find; that guard is now gone.

CMakeLists.txt — specifically the Windows FetchContent block around line 38.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACMakeLists.txt%3A38-41%0AThe%20old%20code%20forced%20%60BUILD_SHARED_LIBS%20OFF%60%20with%20%60CACHE%20...%20FORCE%60%20specifically%20because%20md4c's%20%60CMakeLists.txt%60%20calls%20%60option%28BUILD_SHARED_LIBS%20...%29%60%20under%20the%20CMP0077%20OLD%20policy%2C%20which%20means%20an%20existing%20cache%20value%20%28e.g.%20from%20%60-DBUILD_SHARED_LIBS%3DON%60%20at%20the%20command%20line%20or%20a%20parent%20superbuild%29%20will%20be%20honoured%20as-is%20%E2%80%94%20producing%20a%20%60md4c.dll%60%20that%20then%20needs%20to%20be%20on%20%60PATH%60%20at%20run%20time.%20Without%20the%20%60FORCE%60%20pin%2C%20that%20implicit%20cache%20inheritance%20re-opens%20the%20scenario%20the%20original%20code%20was%20explicitly%20closing%20off.%0A%0A%60%60%60suggestion%0Aif%28WIN32%29%0A%20%20%20%20%23%20No%20dnf%2Fbrew%2Fvcpkg-by-default%20for%20md4c%20here%20%E2%80%94%20fetch%20%26%20build%20it%20just%20to%20dev.%0A%20%20%20%20include%28FetchContent%29%0A%20%20%20%20set%28BUILD_MD2HTML_EXECUTABLE%20OFF%20CACHE%20BOOL%20%22%22%20FORCE%29%0A%20%20%20%20%23%20Force%20static%3A%20md4c%20uses%20CMP0077%20OLD%20so%20its%20option%28%29%20respects%20an%20existing%0A%20%20%20%20%23%20cache%20value%3B%20pin%20it%20here%20so%20-DBUILD_SHARED_LIBS%3DON%20%28e.g.%20from%20a%20superbuild%29%0A%20%20%20%20%23%20doesn't%20silently%20produce%20a%20.dll%20that%20the%20installed%20.exe%20can't%20find.%0A%20%20%20%20set%28BUILD_SHARED_LIBS%20OFF%20CACHE%20BOOL%20%22Build%20md4c%20as%20a%20static%20lib%20on%20Windows%22%20FORCE%29%0A%60%60%60%0A%0A&repo=gesslar%2Fmdv.qt&pr=6&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["tweaks"](https://github.com/gesslar/mdv.qt/commit/429c210a686093a4bac4c8040e0caae72a05b320) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33674345)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->