### PR TITLE
doing some spacing work

### DIFF
--- a/THEMING.md
+++ b/THEMING.md
@@ -36,8 +36,9 @@ What a theme does **not** control, by design:
     "paragraph":   "1em",
     "heading":     "1.5em",
     "list.indent": "1.5em",
-    "code.pad":    "0.75em 1em",
-    "table.cell":  "0.5em 1em"
+    "table.cell":  "1em",
+    "block.pad":   "1em",
+    "block.indent": "1em"
   },
 
   "colors": {
@@ -64,9 +65,8 @@ where transparency isn't meaningful.
 
 Block-fill backgrounds (`code.background`, `blockquote.background`,
 `table.header.background`) may use alpha, but they're flattened onto
-`text.background` at load and render **opaque** — the document engine can't
-paint a translucent block fill without faint per-line seams. You author the
-tint normally; it just resolves to the exact color it would show over the page.
+`text.background` at load and render **opaque**. You author the tint normally;
+it just resolves to the exact color it would show over the page.
 
 ## Spacing keys
 
@@ -75,8 +75,9 @@ tint normally; it just resolves to the exact color it would show over the page.
 | `paragraph`    | vertical margin of paragraphs, lists, quotes |
 | `heading`      | space above headings                         |
 | `list.indent`  | left indent of `ul` / `ol`                   |
-| `code.pad`     | padding inside fenced code blocks            |
 | `table.cell`   | padding of table cells                       |
+| `block.pad`    | padding inside fenced code blocks and blockquotes |
+| `block.indent` | horizontal recess of code blocks and blockquotes |
 
 ## Color keys
 

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -19,11 +19,31 @@ across three, each chosen to work around a QTextDocument/QTextBrowser quirk:
    on the browser. `body { background-color }` doesn't paint the widget viewport;
    QTextBrowser paints it from the palette.
 
-(Code-block token colors are a fourth, separate path — inline `<span style>`
-emitted by the KSyntaxHighlighting pass; see `src/Highlighter.cpp`.)
-
 All three are applied in `DocumentView`'s constructor and re-applied in
 `DocumentView::refresh()`, which Preferences calls after a theme/font change.
+
+## HTML post-processing
+
+The HTML md4c emits is rewritten once before `setHtml()` — `mdv::markdownToHtml`
+runs `wrapBlockquotes` then `highlightCodeBlocks` (`src/Markdown.cpp`):
+
+1. **Code blocks and blockquotes are wrapped in a single-cell table** —
+   `<table class="codeblock">` / `<table class="blockquote">`. This is the
+   constraint behind the template's whole shape: **Qt renders the CSS box model
+   (border + padding) only on table cells, never on block elements.** A `border`
+   or `padding` on `<pre>` or `<blockquote>` is silently dropped, so those frames
+   live on the wrapping cell instead (`table.codeblock td`, `table.blockquote
+   td`). Full width comes from the HTML `width="100%"` attribute — Qt ignores CSS
+   `width` on tables. Only the *outermost* blockquote is wrapped (found by
+   tracking tag depth, since a regex can't match balanced nesting); nested quotes
+   ride along inside the cell.
+2. **Code-block tokens become inline `<span style>`** — emitted by the
+   KSyntaxHighlighting pass and colored from the `syntax.*` palette
+   (`src/Highlighter.cpp`). That's why there are no `syntax.*` rules in the
+   template: those colors arrive inline, per token.
+
+So the template's `pre` and `blockquote` rules are deliberately thin (font,
+whitespace, text color); the visible frame is carried by the `…td` rules.
 
 ## The template
 
@@ -62,19 +82,25 @@ and named colors pass through untouched.
 
 ### `compositeOver` — block-background flattening
 
-QTextDocument fills a block's background **per text-line**, and adjacent line
-rectangles overlap by a sub-pixel — so a *translucent* block fill compounds at
-the seams into faint horizontal lines. To avoid that, the block-fill background
-keys are pre-composited onto the page color and resolve **opaque**:
+These three background keys all render on **table cells** now (code blocks and
+blockquotes are table-wrapped; `th` is already a cell), and a cell fills its
+background as one rectangle. `compositeOver` pre-flattens a translucent value to
+the exact opaque color it would show over `text.background`:
 
 - `code.background`
 - `blockquote.background`
 - `table.header.background`
 
-(see the `blockBackgrounds` set in `ContentTheme::resolveKey`). The composite is
-exact — it's the color the translucent tint would show over `text.background` —
-so authors keep writing natural translucent tints. Opaque inputs pass through
-unchanged.
+(see the `blockBackgrounds` set in `ContentTheme::resolveKey`.) Authors keep
+writing natural translucent tints; they resolve to the equivalent opaque color.
+Opaque inputs pass through unchanged.
+
+> Historically this flattening also dodged a seam artifact: before code blocks
+> and blockquotes were table-wrapped, their translucent fills were painted *per
+> text-line* on the `<pre>`/`<blockquote>` block, and the overlapping line
+> rectangles compounded into faint horizontal lines. The single-rectangle cell
+> fill avoids that structurally now; flattening is kept for the opaque guarantee
+> and gives an identical result.
 
 > Because `text.background` is the composite backdrop **and** is consumed raw via
 > `QPalette` in `DocumentView::applyDocumentPalette()`, it should stay opaque.
@@ -91,4 +117,5 @@ unchanged.
 
 - `resources/content/content.qss.template` — structural CSS + `@{…}` slots
 - `src/ContentTheme.{h,cpp}` — `resolveKey`, `coerceColor`, `compositeOver`, `qss()`
+- `src/Markdown.cpp` — md4c render + HTML post-processing (table wrapping, highlight pass)
 - `src/DocumentView.cpp` — applies the three channels (stylesheet / font / palette)

--- a/resources/content/content.qss.template
+++ b/resources/content/content.qss.template
@@ -49,12 +49,13 @@ ul, ol {
   padding-left: @{spacing.list.indent};
 }
 
+/* Blockquotes are wrapped in a one-cell table (see wrapBlockquotes() in
+ * Markdown.cpp) for the same reason code blocks are: the cell carries the
+ * border and padding, which Qt won't render on the <blockquote> block itself.
+ * The element keeps only its text color and sits flush inside the cell. */
 blockquote {
   color: @{blockquote.foreground};
-  background-color: @{blockquote.background};
-  border-left: 3px solid @{blockquote.border};
-  padding: 0.25em 0.75em;
-  margin: @{spacing.paragraph} 0;
+  margin: 0;
 }
 
 hr {
@@ -63,14 +64,17 @@ hr {
   border: none;
 }
 
+/* The code-block frame — border, padding, single-rectangle background — lives
+ * on the wrapping table cell (see table.codeblock below and
+ * highlightCodeBlocks() in Markdown.cpp). Qt only renders the CSS box model on
+ * table cells, not on block elements, so <pre> itself just carries the
+ * monospace font and preserves whitespace. border-radius is omitted: a
+ * collapsed table cell can't round its corners. */
 pre {
-  background-color: @{code.background};
-  border: 1px solid @{code.border};
-  border-radius: 6px;
-  padding: @{spacing.code.pad};
   font-family: "@{fonts.mono}";
   font-size: 0.92em;
   white-space: pre;
+  margin: 0;
 }
 
 code {
@@ -106,6 +110,37 @@ th {
   background-color: @{table.header.background};
   color: @{table.header.foreground};
   border-bottom: 1px solid @{table.header.foreground};
+}
+
+/* Fenced/indented code blocks are wrapped in a one-cell table so Qt actually
+ * draws their frame. These rules are more specific than the generic td rule
+ * above, so they win — the cell, not the <pre>, owns the border and padding.
+ * Full-width comes from the HTML width="100%" attribute on the <table>
+ * (Markdown.cpp); Qt ignores CSS `width` on tables, so it can't live here. */
+table.codeblock {
+  /* Horizontal margin recesses the block. Overrides the generic `table` rule
+   * above so data tables keep their flush alignment. */
+  margin: @{spacing.paragraph} @{spacing.block.indent};
+}
+
+table.codeblock td {
+  background-color: @{code.background};
+  border: 1px solid @{code.border};
+  padding: @{spacing.block.pad};
+}
+
+/* Blockquotes get the same single-cell-table frame as code blocks, so their
+ * border and padding actually paint. border-left alone gives the classic quote
+ * bar; `border: none` first clears the dotted bottom the generic td rule adds. */
+table.blockquote {
+  margin: @{spacing.paragraph} @{spacing.block.indent};
+}
+
+table.blockquote td {
+  background-color: @{blockquote.background};
+  border: none;
+  border-left: 3px solid @{blockquote.border};
+  padding: @{spacing.block.pad};
 }
 
 /* Code-block token colors are applied as inline styles by the

--- a/resources/themes/blackboard.content.json
+++ b/resources/themes/blackboard.content.json
@@ -6,8 +6,9 @@
     "paragraph":   "1em",
     "heading":     "1.5em",
     "list.indent": "1.5em",
-    "code.pad":    "0.75em 1em",
-    "table.cell":  "0.5em 1em"
+    "table.cell":  "1em",
+    "block.pad":   "1em",
+    "block.indent": "1em"
   },
 
   "colors": {

--- a/resources/themes/bubblegum-goth.content.json
+++ b/resources/themes/bubblegum-goth.content.json
@@ -6,8 +6,9 @@
     "paragraph":   "1em",
     "heading":     "1.5em",
     "list.indent": "1.5em",
-    "code.pad":    "0.75em 1em",
-    "table.cell":  "0.5em 1em"
+    "table.cell":  "1em",
+    "block.pad":   "1em",
+    "block.indent": "1em"
   },
 
   "colors": {

--- a/resources/themes/corporate.content.json
+++ b/resources/themes/corporate.content.json
@@ -6,8 +6,9 @@
     "paragraph":   "1em",
     "heading":     "1.5em",
     "list.indent": "1.5em",
-    "code.pad":    "0.75em 1em",
-    "table.cell":  "0.5em 1em"
+    "table.cell":  "1em",
+    "block.pad":   "1em",
+    "block.indent": "1em"
   },
 
   "colors": {

--- a/src/Markdown.cpp
+++ b/src/Markdown.cpp
@@ -109,7 +109,8 @@ QString wrapBlockquotes(const QString &html) {
         // Flush the prose before this blockquote, then open the wrapper. The
         // blockquote's own markup is emitted when its matching close is found.
         out.append(QStringView(html).sliced(copied, nextOpen - copied));
-        out.append(QStringLiteral("<table class=\"blockquote\"><tr><td>"));
+        out.append(QStringLiteral(
+            "<table class=\"blockquote\" width=\"100%\"><tr><td>"));
         copied = nextOpen;
       }
       ++depth;

--- a/src/Markdown.cpp
+++ b/src/Markdown.cpp
@@ -58,21 +58,73 @@ QString highlightCodeBlocks(const QString &html) {
     // whitespace-delimited token.
     const QString lang =
         m.captured(1).split(QLatin1Char(' '), Qt::SkipEmptyParts).value(0);
+    // Wrap each block in a single-cell table. Qt's QTextDocument only renders
+    // the CSS box model (border + padding) on table cells, never on block
+    // elements like <pre>, so the cell is what carries the frame and the inset.
+    // It also fills the background as one rectangle instead of the per-line
+    // fill a <pre> background does — which is what caused the seam artifacts.
     if (lang.isEmpty()) {
       // Unlabeled / unknown blocks aren't highlighted; re-emit the already-
       // escaped content with the trailing newline trimmed.
-      out.append(QStringLiteral("<pre><code>"));
+      out.append(QStringLiteral(
+          "<table class=\"codeblock\" width=\"100%\"><tr><td><pre><code>"));
       out.append(inner);
-      out.append(QStringLiteral("</code></pre>"));
+      out.append(QStringLiteral("</code></pre></td></tr></table>"));
       continue;
     }
 
-    out.append(QStringLiteral("<pre><code class=\"language-%1\">")
+    out.append(QStringLiteral("<table class=\"codeblock\" width=\"100%\">"
+                              "<tr><td><pre><code class=\"language-%1\">")
                    .arg(lang.toHtmlEscaped()));
     out.append(highlightCode(unescapeHtml(inner), lang));
-    out.append(QStringLiteral("</code></pre>"));
+    out.append(QStringLiteral("</code></pre></td></tr></table>"));
   }
   out.append(QStringView(html).sliced(last));
+  return out;
+}
+
+// Wrap each top-level <blockquote> in a single-cell table, mirroring the code
+// block treatment: Qt only renders the CSS box model (border, padding) on table
+// cells, never on block elements, so the cell is what carries the blockquote's
+// border and inset. Only the outermost blockquote is wrapped — nested ones ride
+// along inside the cell — and we find its matching close by tracking tag depth,
+// which a regex can't do for arbitrary nesting.
+QString wrapBlockquotes(const QString &html) {
+  static const QString open = QStringLiteral("<blockquote>");
+  static const QString close = QStringLiteral("</blockquote>");
+
+  QString out;
+  out.reserve(html.size() + 64);
+
+  int depth = 0;
+  qsizetype copied = 0;  // everything before this index is already in `out`
+  qsizetype pos = 0;
+  while (pos < html.size()) {
+    const qsizetype nextOpen = html.indexOf(open, pos);
+    const qsizetype nextClose = html.indexOf(close, pos);
+    if (nextClose < 0) break;  // no more well-formed blockquotes
+
+    if (nextOpen >= 0 && nextOpen < nextClose) {
+      if (depth == 0) {
+        // Flush the prose before this blockquote, then open the wrapper. The
+        // blockquote's own markup is emitted when its matching close is found.
+        out.append(QStringView(html).sliced(copied, nextOpen - copied));
+        out.append(QStringLiteral("<table class=\"blockquote\"><tr><td>"));
+        copied = nextOpen;
+      }
+      ++depth;
+      pos = nextOpen + open.size();
+    } else {
+      if (depth > 0 && --depth == 0) {
+        const qsizetype end = nextClose + close.size();
+        out.append(QStringView(html).sliced(copied, end - copied));
+        out.append(QStringLiteral("</td></tr></table>"));
+        copied = end;
+      }
+      pos = nextClose + close.size();
+    }
+  }
+  out.append(QStringView(html).sliced(copied));
   return out;
 }
 
@@ -104,7 +156,10 @@ QString markdownToHtml(const QString &markdown) {
     return QStringLiteral("<pre>%1</pre>").arg(markdown.toHtmlEscaped());
   }
 
-  return highlightCodeBlocks(QString::fromUtf8(html));
+  // Blockquotes are wrapped first, on the clean md4c output where <blockquote>
+  // only ever appears as a real tag; code-block highlighting runs after and
+  // still finds any <pre><code> nested inside a wrapped quote.
+  return highlightCodeBlocks(wrapBlockquotes(QString::fromUtf8(html)));
 }
 
 }  // namespace mdv


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors how code blocks and blockquotes are styled by wrapping both in single-cell `<table>` elements in the HTML post-processing step, working around Qt's QTextDocument limitation that ignores `border` and `padding` on block elements like `<pre>` and `<blockquote>`. The theme spacing schema is updated to replace `code.pad` with the unified `block.pad`/`block.indent` keys.

- **New `wrapBlockquotes()` function** (`src/Markdown.cpp`): depth-tracking linear scan wraps each top-level `<blockquote>` in `<table class="blockquote" width="100%"><tr><td>…</td></tr></table>`, mirroring the existing code-block wrapping in `highlightCodeBlocks()`.
- **CSS template updated** (`content.qss.template`): `blockquote` and `pre` rules are stripped of their frame properties; those now live on `table.blockquote td` and `table.codeblock td` respectively, which Qt does render correctly.
- **All three theme files** updated with the renamed `block.pad`/`block.indent` spacing keys; `ContentTheme` looks these up dynamically so no C++ changes were needed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are self-contained HTML post-processing and CSS/theme updates with no impact on data or application state.

The `wrapBlockquotes` depth-tracking logic is correct for well-formed HTML (which md4c always produces), the `width="100%"` attribute is present on both table wrappers, the spacing key rename is consistent across all three theme files and the CSS template, and `ContentTheme`'s dynamic key lookup means no C++ changes are needed. No logic defects or broken invariants were found.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["fixy fixy"](https://github.com/gesslar/mdv.qt/commit/9ad60cc4ad416c6eb553b3be6028e0ade4c45e58) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33695797)</sub>

<!-- /greptile_comment -->