### PR TITLE
watch mode wired up

### DIFF
--- a/src/DocumentView.cpp
+++ b/src/DocumentView.cpp
@@ -295,6 +295,7 @@ void DocumentView::setPinned(bool on) {
 void DocumentView::setWatching(bool on) {
   if (m_watching == on) return;
   m_watching = on;
+  if (!on) m_reloadTimer->stop();  // cancel any reload queued in the debounce
   armWatch();
 }
 
@@ -316,7 +317,10 @@ void DocumentView::onFileChanged(const QString &) {
 }
 
 void DocumentView::reloadFromDisk() {
-  if (m_filePath.isEmpty()) return;
+  // Guard m_watching too: a reload queued in the debounce window must not fire
+  // after watch was switched off (setWatching stops the timer, but this also
+  // covers any other path that could leave it pending).
+  if (!m_watching || m_filePath.isEmpty()) return;
 
   QFile file(m_filePath);
   if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {

--- a/src/DocumentView.cpp
+++ b/src/DocumentView.cpp
@@ -1,11 +1,14 @@
 #include "DocumentView.h"
 
+#include <algorithm>
+
 #include <QAbstractTextDocumentLayout>
 #include <QColor>
 #include <QDesktopServices>
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QFileSystemWatcher>
 #include <QFont>
 #include <QMenu>
 #include <QMessageBox>
@@ -67,6 +70,15 @@ DocumentView::DocumentView(QWidget *parent) : QWidget(parent) {
     }
     m_pendingAnchor = -1;
   });
+
+  // Hot reload. fileChanged fires on external writes; the reload timer
+  // debounces the burst a save produces before we re-render in place.
+  m_watcher = new QFileSystemWatcher(this);
+  connect(m_watcher, &QFileSystemWatcher::fileChanged, this,
+          &DocumentView::onFileChanged);
+  m_reloadTimer = new QTimer(this);
+  m_reloadTimer->setSingleShot(true);
+  connect(m_reloadTimer, &QTimer::timeout, this, &DocumentView::reloadFromDisk);
 }
 
 bool DocumentView::loadFile(const QString &path) {
@@ -101,6 +113,7 @@ bool DocumentView::loadFile(const QString &path) {
   m_filePath = info.canonicalFilePath();
   if (m_filePath.isEmpty()) m_filePath = info.absoluteFilePath();
 
+  armWatch();
   emit fileLoaded(m_filePath);
   return true;
 }
@@ -277,4 +290,90 @@ void DocumentView::setPinned(bool on) {
   if (m_pinned == on) return;
   m_pinned = on;
   emit pinnedChanged(on);
+}
+
+void DocumentView::setWatching(bool on) {
+  if (m_watching == on) return;
+  m_watching = on;
+  armWatch();
+}
+
+void DocumentView::armWatch() {
+  if (!m_watcher) return;
+  // Clear the current path, then re-add if we should be watching. (removePaths
+  // on an empty list is a no-op; an atomic save drops the path, so re-arming
+  // after each reload re-points us at the new inode.)
+  const QStringList watched = m_watcher->files();
+  if (!watched.isEmpty()) m_watcher->removePaths(watched);
+  if (m_watching && !m_filePath.isEmpty() && QFileInfo::exists(m_filePath))
+    m_watcher->addPath(m_filePath);
+}
+
+void DocumentView::onFileChanged(const QString &) {
+  if (!m_watching) return;
+  // Coalesce the burst of events a save produces; reload once it settles.
+  m_reloadTimer->start(120);
+}
+
+void DocumentView::reloadFromDisk() {
+  if (m_filePath.isEmpty()) return;
+
+  QFile file(m_filePath);
+  if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    // Mid-save the file can be briefly unreadable (atomic rename in flight) —
+    // bail quietly and re-arm; another change event will bring us back.
+    armWatch();
+    return;
+  }
+  QTextStream in(&file);
+  in.setEncoding(QStringConverter::Utf8);
+  const QString html = mdv::markdownToHtml(in.readAll());
+
+  // Capture the view state before swapping. The anchor is a character offset
+  // into the current rendered text; oldText is that same text (so the diff in
+  // remapAnchor lives in the anchor's coordinate space). The font — including
+  // any Ctrl+wheel zoom — is left untouched, so a content-only setHtml()
+  // preserves the zoom for free.
+  const int anchor = topAnchor();
+  const QString oldText = m_browser->document()->toPlainText();
+
+  m_browser->setHtml(html);
+
+  const QString newText = m_browser->document()->toPlainText();
+  scrollToAnchor(remapAnchor(anchor, oldText, newText));
+
+  // Re-point the watcher (an atomic save dropped the path).
+  armWatch();
+}
+
+int DocumentView::remapAnchor(int pos, const QString &oldText,
+                              const QString &newText) const {
+  const int oldLen = oldText.size();
+  const int newLen = newText.size();
+
+  // Common prefix and (non-overlapping) common suffix bound the changed region
+  // to [prefix, oldLen - suffix) in the old text's coordinates.
+  int prefix = 0;
+  const int maxPrefix = std::min(oldLen, newLen);
+  while (prefix < maxPrefix && oldText[prefix] == newText[prefix]) ++prefix;
+
+  int suffix = 0;
+  const int maxSuffix = std::min(oldLen, newLen) - prefix;
+  while (suffix < maxSuffix &&
+         oldText[oldLen - 1 - suffix] == newText[newLen - 1 - suffix]) {
+    ++suffix;
+  }
+
+  const int changeStart = prefix;
+  const int changeEnd = oldLen - suffix;  // exclusive
+
+  int mapped;
+  if (pos <= changeStart) {
+    mapped = pos;  // edit was below the anchor — offset unchanged
+  } else if (pos >= changeEnd) {
+    mapped = pos + (newLen - oldLen);  // edit was above — shift by net delta
+  } else {
+    mapped = changeStart;  // anchor sat inside the edit — best-effort positional
+  }
+  return std::clamp(mapped, 0, newLen);
 }

--- a/src/DocumentView.h
+++ b/src/DocumentView.h
@@ -3,7 +3,9 @@
 #include <QPoint>
 #include <QWidget>
 
+class QFileSystemWatcher;
 class QTextBrowser;
+class QTimer;
 class QUrl;
 
 class DocumentView : public QWidget {
@@ -56,7 +58,9 @@ public:
   void setPinned(bool on);
 
   bool isWatching() const { return m_watching; }
-  void setWatching(bool on) { m_watching = on; }
+  // Start/stop watching the file on disk. While watching, an external write
+  // triggers an in-place reload that preserves zoom and scroll position.
+  void setWatching(bool on);
 
 signals:
   void fileLoaded(const QString &canonicalPath);
@@ -72,12 +76,19 @@ signals:
 private slots:
   void onContextMenuRequested(const QPoint &pos);
   void onAnchorClicked(const QUrl &url);
+  // The watched file changed on disk — debounced before reloadFromDisk().
+  void onFileChanged(const QString &path);
 
 private:
   QTextBrowser *m_browser = nullptr;
   QString m_filePath;
   bool m_pinned = false;
   bool m_watching = true;
+
+  // Hot reload: m_watcher fires on external writes; m_reloadTimer debounces
+  // the burst of events editors emit before we re-render in place.
+  QFileSystemWatcher *m_watcher = nullptr;
+  QTimer *m_reloadTimer = nullptr;
 
   // Pending scroll anchor state used by scrollToAnchor() to defer until
   // QTextDocument has laid out enough to know each block's geometry.
@@ -87,4 +98,19 @@ private:
   class QTimer *m_pendingAnchorTimer = nullptr;
 
   bool tryApplyAnchor();
+
+  // (Re)point the watcher at m_filePath when watching is on; clears it
+  // otherwise. Safe to call repeatedly (used after load and after each reload,
+  // since an atomic save drops the watched path).
+  void armWatch();
+
+  // Re-render the file in place, preserving zoom (the font is left untouched)
+  // and scroll position (remapped across the edit via remapAnchor).
+  void reloadFromDisk();
+
+  // Map a character offset from the old rendered plain text to the new one
+  // using a common prefix/suffix diff: unchanged if the edit was below it,
+  // shifted by the net length delta if above, best-effort positional if the
+  // offset falls inside the changed region.
+  int remapAnchor(int pos, const QString &oldText, const QString &newText) const;
 };


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up the watch mode feature, adding live file reloading to `DocumentView`. When a watched file changes on disk, a 120 ms debounce timer coalesces save bursts before re-rendering the document in place, while preserving scroll position and zoom.

- `QFileSystemWatcher` + `QTimer` are set up in the constructor; `armWatch()` re-points the watcher at the current file's inode after each reload (necessary for atomic-save editors that replace the inode).
- `setWatching()` is upgraded from a trivial inline setter to a proper method that stops the debounce timer and calls `armWatch()` when disabling, fixing the stale-reload race flagged in the previous review.
- `remapAnchor()` maps the pre-reload scroll offset into the new document's coordinate space using a common prefix/suffix diff, with `std::clamp` as a safety net.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the implementation is well-guarded and the previously identified stale-reload race has been closed with both a timer stop and an early-return guard.

Both defensive measures are in place: `setWatching(false)` calls `m_reloadTimer->stop()` and `reloadFromDisk()` returns early if `m_watching` is false. `armWatch()` correctly re-points the watcher at the new inode after atomic saves. `remapAnchor()` handles all boundary cases including empty old/new texts and inserts-at-boundary. No commented-out code, no rule violations found.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["fixes"](https://github.com/gesslar/mdv.qt/commit/69a5c40a4a63c223cee836ad19ebfc667fc1b532) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33714095)</sub>

<!-- /greptile_comment -->