### PR TITLE
windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,24 @@ find_package(Qt6 6.5 REQUIRED COMPONENTS Widgets)
 # FetchContent exports the plain target md4c-html. The ${MD4C} indirection
 # papers over that difference so the link line stays uniform.
 if(WIN32)
+    # FetchContent'd subprojects (md4c, KSH, ECM) all call install() at
+    # configure time. Those rules bake into cmake_install.cmake and CPack
+    # would otherwise ship md4c headers, KSH .cmake configs, etc. as part of
+    # the mdv installer. The clean way to silence them is to override the
+    # built-in install() command with a gated forwarder: by default it's a
+    # no-op, and we flip the gate ON only for our own install rules below.
+    #
+    # Redefining install() makes the original built-in reachable as _install
+    # (CMake renames the prior definition under that underscore name). One
+    # level of shadowing is reliable; doing it more than once gets ambiguous,
+    # which is why we use a single override + a flag rather than re-overriding.
+    set(_mdv_install_enabled OFF)
+    function(install)
+        if(_mdv_install_enabled)
+            _install(${ARGV})
+        endif()
+    endfunction()
+
     # No dnf/brew/vcpkg-by-default for md4c here — fetch & build it just to dev.
     include(FetchContent)
     set(BUILD_MD2HTML_EXECUTABLE OFF CACHE BOOL "" FORCE)
@@ -53,11 +71,148 @@ else()
 endif()
 
 # KSyntaxHighlighting — code-block tokenizer; we map its default styles onto
-# the active content theme's syntax.* colors. find_package resolves it on
-# every platform, but the Qt installer doesn't bundle KF6: on Windows install
-# it via KDE Craft and on macOS via MacPorts/Craft, then point CMake at it with
-# -DCMAKE_PREFIX_PATH=<prefix>. See DEVELOPMENT.md for the per-platform steps.
-find_package(KF6SyntaxHighlighting REQUIRED)
+# the active content theme's syntax.* colors.
+#
+# Same acquisition rule as md4c: system package on Linux/macOS, FetchContent on
+# Windows where there's no package. KSH is a KDE Framework, so the Windows
+# branch also has to FetchContent extra-cmake-modules (ECM) first — KSH does
+# find_package(ECM) at configure time. The KSH build also runs the
+# katehighlightingindexer host tool and lrelease, which is why this is a
+# *native* Windows path only (cross-compiling KSH from Linux trips on host
+# tools — see work/windows-cross-notes.md for why we abandoned that).
+#
+# As with md4c, the imported target names differ between paths:
+# find_package gives `KF6::SyntaxHighlighting`; the in-build FetchContent gives
+# the same namespaced alias (KDE Frameworks add it via add_library(ALIAS)).
+# The ${KSH} indirection keeps the link line uniform regardless.
+if(WIN32)
+    # KSH pulls Qt6::Network transitively. On Linux/macOS the system
+    # find_package(KF6SyntaxHighlighting) drags it in via the exported config's
+    # find_dependency(); on the FetchContent path the consumer (this project)
+    # has to declare it. Add it once here so the warning goes away and the
+    # link line is honest.
+    find_package(Qt6 6.5 REQUIRED COMPONENTS Network)
+
+    include(FetchContent)
+    set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+    # XercesC is an optional KSH dep used for richer XML validation; we don't
+    # need it, and skipping the find_package avoids a "not found" warning on
+    # boxes without it. Translations + the katehighlightingindexer build and
+    # run natively here, so they don't need disabling.
+    #
+    # KSH's CMakeLists also hard-codes add_subdirectory(examples) and
+    # add_subdirectory(src/cli) with no off-switch — they build alongside the
+    # library. They don't affect the mdv.exe link and their install() rules
+    # are suppressed below, so we just absorb the extra build time.
+    set(CMAKE_DISABLE_FIND_PACKAGE_XercesC ON CACHE BOOL "" FORCE)
+
+    # --- extra-cmake-modules ----------------------------------------------
+    #
+    # KSH's CMakeLists does find_package(ECM NO_MODULE REQUIRED) plus a
+    # batch of include(ECM*). FetchContent_MakeAvailable() on ECM by itself
+    # is not enough: ECM's build-tree ECMConfig.cmake sets its module path
+    # to the eventual install location (which doesn't exist), so the
+    # subsequent include() calls in KSH fail to find ECMGenerateHeaders etc.
+    #
+    # ECM is a pure-CMake "no compile" project — installing it is just a
+    # file copy. So we clone, configure, and install it to a local prefix
+    # inside the build dir, then add that prefix to CMAKE_PREFIX_PATH. From
+    # KSH's point of view ECM looks system-installed and everything resolves.
+    #
+    # We cache the install (gate on ECMConfig.cmake's existence) so reconfigures
+    # don't re-clone.
+    set(ECM_LOCAL_PREFIX "${CMAKE_BINARY_DIR}/_ecm-prefix")
+    if(NOT EXISTS "${ECM_LOCAL_PREFIX}/share/ECM/cmake/ECMConfig.cmake")
+        set(_ecm_src "${CMAKE_BINARY_DIR}/_ecm-src")
+        set(_ecm_bld "${CMAKE_BINARY_DIR}/_ecm-build")
+        if(NOT EXISTS "${_ecm_src}/CMakeLists.txt")
+            find_package(Git REQUIRED)
+            file(REMOVE_RECURSE "${_ecm_src}")
+            execute_process(
+                COMMAND "${GIT_EXECUTABLE}" clone --depth 1
+                    --branch v6.26.0
+                    https://invent.kde.org/frameworks/extra-cmake-modules.git
+                    "${_ecm_src}"
+                RESULT_VARIABLE _ecm_clone)
+            if(NOT _ecm_clone EQUAL 0)
+                message(FATAL_ERROR "ECM clone failed (exit ${_ecm_clone})")
+            endif()
+        endif()
+        execute_process(
+            COMMAND "${CMAKE_COMMAND}"
+                -S "${_ecm_src}" -B "${_ecm_bld}"
+                -G "${CMAKE_GENERATOR}"
+                "-DCMAKE_INSTALL_PREFIX=${ECM_LOCAL_PREFIX}"
+                -DBUILD_TESTING=OFF
+            RESULT_VARIABLE _ecm_cfg)
+        if(NOT _ecm_cfg EQUAL 0)
+            message(FATAL_ERROR "ECM configure failed (exit ${_ecm_cfg})")
+        endif()
+        execute_process(
+            COMMAND "${CMAKE_COMMAND}" --install "${_ecm_bld}"
+            RESULT_VARIABLE _ecm_install)
+        if(NOT _ecm_install EQUAL 0)
+            message(FATAL_ERROR "ECM install failed (exit ${_ecm_install})")
+        endif()
+    endif()
+    list(PREPEND CMAKE_PREFIX_PATH "${ECM_LOCAL_PREFIX}")
+
+    # --- Perl (KSH build-time dep) ----------------------------------------
+    #
+    # KSH runs a Perl script during configure (the regex tester). Windows
+    # doesn't ship Perl, but Git for Windows bundles one at
+    # <git-prefix>/usr/bin/perl.exe, which the user already has installed if
+    # they got here. Probe for it and seed PERL_EXECUTABLE if not on PATH,
+    # so KSH's find_package(Perl) succeeds without the user having to install
+    # Strawberry Perl separately. The CI side can `choco install strawberryperl`
+    # if it'd rather have a dedicated one — this stays a fallback.
+    find_program(PERL_EXECUTABLE perl)
+    if(NOT PERL_EXECUTABLE)
+        find_package(Git QUIET)
+        if(GIT_EXECUTABLE)
+            get_filename_component(_git_bin "${GIT_EXECUTABLE}" DIRECTORY)
+            get_filename_component(_git_prefix "${_git_bin}" DIRECTORY)
+            find_program(PERL_EXECUTABLE perl
+                HINTS "${_git_prefix}/usr/bin"
+                NO_DEFAULT_PATH)
+        endif()
+    endif()
+    if(NOT PERL_EXECUTABLE)
+        message(FATAL_ERROR
+            "Perl is required to build KSyntaxHighlighting on Windows. "
+            "Install Strawberry Perl (choco install strawberryperl) or "
+            "Git for Windows (which bundles a Perl), and reconfigure.")
+    endif()
+
+    # --- KSyntaxHighlighting ----------------------------------------------
+    #
+    # Pinned to v6.26.0 so the API matches the Linux/macOS find_package side
+    # (system KF6 is 6.26.0 on the dev box). With ECM resolvable from the
+    # prefix above, KSH builds + installs its data resources into the lib,
+    # so the deployed DLL travels with all syntax/theme defs baked in.
+    FetchContent_Declare(
+        KSyntaxHighlighting
+        GIT_REPOSITORY https://invent.kde.org/frameworks/syntax-highlighting.git
+        GIT_TAG v6.26.0
+        GIT_SHALLOW TRUE
+    )
+    # install() is still gated OFF here (set at the top of this if(WIN32)
+    # branch), so KSH's install rules — like md4c's above — become no-ops.
+    FetchContent_MakeAvailable(KSyntaxHighlighting)
+    # KSH only adds the KF6:: namespaced alias on *install* (the exported
+    # config does add_library(KF6::SyntaxHighlighting IMPORTED)). In-tree
+    # the target is just `KF6SyntaxHighlighting`. Add the alias ourselves so
+    # the ${KSH} indirection points at the same name on every platform.
+    if(NOT TARGET KF6::SyntaxHighlighting)
+        add_library(KF6::SyntaxHighlighting ALIAS KF6SyntaxHighlighting)
+    endif()
+    set(KSH KF6::SyntaxHighlighting)
+else()
+    # The Qt installer doesn't bundle KF6, so off Linux/macOS-with-MacPorts the
+    # user supplies it via -DCMAKE_PREFIX_PATH=<prefix>. See DEVELOPMENT.md.
+    find_package(KF6SyntaxHighlighting REQUIRED)
+    set(KSH KF6::SyntaxHighlighting)
+endif()
 
 qt_standard_project_setup()
 
@@ -86,7 +241,15 @@ qt_add_executable(mdv
     resources/resources.qrc
 )
 
-target_link_libraries(mdv PRIVATE Qt6::Widgets ${MD4C} KF6::SyntaxHighlighting)
+# Windows app icon: embed resources/mdv.rc → mdv.ico into the executable so
+# Explorer, the taskbar, Start Menu shortcuts, and the Apps & Features entry
+# render the app icon (without this they fall back to the generic exe icon).
+# CMake autoselects windres on MinGW / rc.exe on MSVC.
+if(WIN32)
+    target_sources(mdv PRIVATE resources/mdv.rc)
+endif()
+
+target_link_libraries(mdv PRIVATE Qt6::Widgets ${MD4C} ${KSH})
 
 target_include_directories(mdv PRIVATE src)
 
@@ -113,6 +276,30 @@ if(UNIX AND NOT APPLE)
     install(FILES resources/icons/mdv.png
         DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/512x512/apps
         RENAME mdv.png)
+endif()
+
+# Windows install layout follows the Qt deploy convention:
+#   <prefix>/bin/mdv.exe  + Qt6*.dll + mingw runtime DLLs + qt.conf
+#   <prefix>/plugins/{platforms,styles,imageformats,...}
+#   <prefix>/translations/qt_*.qm
+# qt.conf in bin/ has `Prefix = ..` so the Qt runtime walks back up to find
+# plugins/ and translations/. windeployqt produces exactly this shape;
+# qt_generate_deploy_app_script() runs windeployqt at install time so CPack's
+# staging step picks it up. CPack's NSIS template auto-points the Start Menu
+# / desktop shortcut at $INSTDIR\bin\mdv.exe to match.
+if(WIN32)
+    # Flip the install() gate ON — until now it's been a no-op so md4c/KSH/ECM
+    # didn't bake their install rules into our package. Our own install rules
+    # need the real install() built-in (reachable as _install thanks to the
+    # function override above).
+    set(_mdv_install_enabled ON)
+    install(TARGETS mdv RUNTIME DESTINATION bin)
+    install(FILES resources/icons/mdv.ico DESTINATION bin)
+    qt_generate_deploy_app_script(
+        TARGET mdv
+        OUTPUT_SCRIPT _mdv_deploy_script
+        NO_UNSUPPORTED_PLATFORM_ERROR)
+    install(SCRIPT ${_mdv_deploy_script})
 endif()
 
 # CPack: turn the install() rules above into .deb / .rpm. Kept in its own file

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,10 +11,11 @@
 
 > The rule for the two non-Qt deps: take them from the system package manager
 > wherever it has them. On Linux that's both (install with the commands below).
-> md4c has no package on Windows, so CMake fetches and builds it in-tree there —
-> nothing to install. KSyntaxHighlighting isn't carried by the Qt installer on
-> Windows or by Homebrew on macOS; install it via KDE Craft (or MacPorts) and
-> point CMake at it with `-DCMAKE_PREFIX_PATH`. The per-platform steps are below.
+> On Windows neither is packaged, so CMake fetches and builds them in-tree
+> (md4c, plus KSyntaxHighlighting + extra-cmake-modules) — nothing to install
+> beyond Qt + a C++ toolchain. On macOS, KSyntaxHighlighting isn't carried by
+> Homebrew; install it via MacPorts (or KDE Craft) and point CMake at it with
+> `-DCMAKE_PREFIX_PATH`. The per-platform steps are below.
 
 ## Installing dependencies
 
@@ -60,26 +61,16 @@ KSyntaxHighlighting (KDE Frameworks 6) isn't in Homebrew core; on macOS install 
 
 ### Windows
 
-Install the official **[Qt online installer](https://www.qt.io/download-qt-installer)** and select Qt 6.5+ with **MSVC 2022 64-bit** (or MinGW if you prefer). The installer also bundles CMake, Ninja, and Qt Creator.
+Install the official **[Qt online installer](https://www.qt.io/download-qt-installer)** and select Qt 6.5+ with **MinGW 64-bit** (the version this project was developed against; MSVC 2022 64-bit also works). Include **Qt Linguist / qttools** in the install — KSyntaxHighlighting's translation step needs `lrelease` on `PATH`. The Qt installer also bundles CMake, Ninja, and Qt Creator.
 
-If you'd rather use system tooling: install **Visual Studio 2022** (with the "Desktop development with C++" workload) and a standalone CMake.
+Two extra prereqs that the Qt installer doesn't provide:
 
-**md4c** has no Windows package, so CMake fetches and builds it in-tree — nothing to install.
+- **Git for Windows** — `git` is needed at *configure* time (CMake clones extra-cmake-modules from invent.kde.org) and Git for Windows also ships a Perl at `C:\Program Files\Git\usr\bin\perl.exe`, which is what KSyntaxHighlighting needs to generate its data tables. CMakeLists auto-detects this Perl when one isn't already on `PATH`. If you'd rather use Strawberry Perl: `choco install strawberryperl`.
+- **NSIS 3.x** (`makensis.exe`) — only needed for `make exe` (building the installer). `choco install nsis`, or download from <https://nsis.sourceforge.io/> and add `NSIS\Bin` to `PATH`.
 
-**KSyntaxHighlighting** isn't bundled by the Qt installer. Get it from **[KDE Craft](https://community.kde.org/Craft)**, KDE's build system for Windows (it pulls in extra-cmake-modules and the syntax/theme data for you):
+Neither **md4c** nor **KSyntaxHighlighting** has a Windows package, so CMake fetches and builds both in-tree on Windows (along with extra-cmake-modules, which KSH needs). Nothing extra to install for them — `cmake -S . -B build-release -G Ninja -DCMAKE_BUILD_TYPE=Release` and `cmake --build build-release` is enough on a clean machine that has Qt + a compiler + Git.
 
-```powershell
-# In a Craft shell, after the one-time Craft setup:
-craft kf6-syntax-highlighting
-```
-
-Then point CMake at the Craft prefix when configuring:
-
-```powershell
-cmake -S . -B build -G Ninja -DCMAKE_PREFIX_PATH=C:/CraftRoot
-```
-
-(Use your actual `CraftRoot` path. The same `-DCMAKE_PREFIX_PATH` trick is how the macOS MacPorts/Craft install gets found.)
+The first configure also clones and locally installs **extra-cmake-modules** into `build-release/_ecm-prefix/` (a build-tree-only install — nothing leaks into the system). That step is cached, so reconfigures don't re-clone.
 
 ## Building
 
@@ -141,8 +132,68 @@ soname packages, which are the wrong names for a `.deb`. Keep it in step with
 the link line if you add a library. RPM `Requires:` are auto-detected by
 `rpmbuild`.
 
-Windows and macOS will get their own `Makefile.dist.windows` /
-`Makefile.dist.macos` includes when those build paths are ready.
+macOS will get its own `Makefile.dist.macos` include when that build path is
+ready.
+
+## Packaging (Windows)
+
+The Windows installer is an NSIS `.exe` built with CPack from the same
+`install()` rules `cmake --install` uses (the binary, the icon, and a
+windeployqt step that pulls in Qt + plugins + translations + the mingw
+runtime DLLs). The target lives in `Makefile.dist.windows` — the top-level
+Makefile pulls in the per-OS dist include for the host automatically.
+Installer metadata (file associations, shortcuts, icons) lives in
+`cmake/Packaging.cmake`.
+
+```powershell
+make exe     # → dist\mdv-<version>-win64.exe
+make dist    # same (alias, parallel to Linux's `make dist`)
+```
+
+`make exe` builds the release binary first, then runs `cpack -G NSIS`;
+the artifact lands in `dist\`. **Packaging tooling**: NSIS 3.x must be
+installed and `makensis.exe` on `PATH` (see the Windows install section
+above).
+
+The resulting installer:
+
+- Starts **unprivileged** (manifest `requestedExecutionLevel="asInvoker"`).
+  No UAC prompt appears on launch.
+- Shows a custom "Choose Installation Type" page after the licence with two
+  radio buttons:
+  - **Install for me only** (default) → installs to `%LOCALAPPDATA%\Programs\mdv\`,
+    HKCU. No elevation needed.
+  - **Install for all users** → installs to `Program Files\mdv\`, HKLM. If
+    the user isn't already an admin, the installer **relaunches itself with
+    `runas`** at this point, which is what finally triggers the UAC prompt.
+    The elevated instance picks up a `/AllUsers` flag and skips the choice
+    page so the user isn't asked twice.
+- The next page lets the user override the install directory.
+- Lays down `bin\mdv.exe` + Qt DLLs + plugins + translations + `mdv.ico`,
+  matching the windeployqt layout (`qt.conf` in `bin\` points the runtime at
+  `..\plugins` and `..\translations`).
+- Creates Start Menu and Desktop shortcuts. NSIS resolves `$SMPROGRAMS` /
+  `$DESKTOP` against the chosen install scope — per-user installs target
+  the user's own shell folders (including OneDrive-synced Desktops);
+  per-machine installs target the All Users folders.
+- Registers file associations for `.md` / `.markdown` / `.mkd` against an
+  `mdv.markdown` ProgID under `SHCTX\Software\Classes` (= `HKCU` per-user,
+  `HKLM` per-machine). The uninstaller removes them.
+- Writes an Add/Remove Programs entry under the same hive so the install
+  shows up in Apps & Features with publisher, version, homepage, and a
+  scope-aware uninstall command (`/CurrentUser` or `/AllUsers`).
+
+Two NSIS-related notes for anyone editing `cmake/mdv.nsi.in`:
+
+- **We don't use CPack's bundled NSIS template** — it hard-codes
+  `RequestExecutionLevel admin`, which forces UAC at launch even on per-user
+  installs. The custom `.nsi.in` is driven by a `package_nsis` CMake target.
+  Linux's CPack path for `.deb` / `.rpm` is unaffected.
+- **We don't use NSIS's `MultiUser.nsh` either** — its `Highest` execution
+  level also triggers UAC at launch (before the choice page), and `Standard`
+  never elevates at all. Neither matches "elevate only if the user picks
+  per-machine". We hand-roll the elevation dance in ~50 lines using
+  `nsDialogs` + `ExecShell "runas"`.
 
 ## Using Qt Creator
 

--- a/Makefile.dist.windows
+++ b/Makefile.dist.windows
@@ -1,0 +1,38 @@
+# Windows packaging targets — pulled in by the top-level Makefile when
+# building on Windows. Produces an NSIS installer via a custom CMake target
+# (NOT CPack — see cmake/Packaging.cmake for why), driving makensis against
+# cmake/mdv.nsi.in.
+#
+#     make exe    → dist/mdv-<version>-win64.exe
+#     make dist   → same
+#
+# The installer offers the user a choice between per-user (no admin, install
+# to %LOCALAPPDATA%\Programs\mdv) and per-machine (admin, Program Files\mdv)
+# via NSIS MultiUser.nsh. Shortcuts and registry hive follow that choice.
+#
+# Prereqs:
+#   - NSIS 3.x (makensis.exe) — `choco install nsis` or install from
+#     https://nsis.sourceforge.io/ and ensure NSIS\Bin is on PATH. CMake's
+#     find_program() also checks the default Program Files locations.
+#   - Perl, needed by KSyntaxHighlighting at configure time. Git for Windows
+#     bundles one at <git-prefix>/usr/bin/perl.exe and CMakeLists auto-detects
+#     it; otherwise `choco install strawberryperl`.
+# See DEVELOPMENT.md for the full Windows setup.
+#
+# DIST_DIR (the output directory) comes from the top-level Makefile, alongside
+# DEV_DIR / RELEASE_DIR, so `make distclean` there can sweep it too.
+
+.PHONY: dist exe
+
+# Every Windows package format. Single artifact today; keeps the verb parallel
+# to `make dist` on Linux (which fans out to deb + rpm).
+dist: exe
+
+# Re-configure the release tree with MDV_PACKAGE_OUTPUT_DIR pointing at our
+# DIST_DIR (otherwise the artifact lands inside the build dir), then drive
+# the package_nsis custom target. The target stages the install tree via
+# `cmake --install` and runs makensis on the generated mdv.nsi.
+exe: release
+	cmake -S . -B $(RELEASE_DIR) -G Ninja -DCMAKE_BUILD_TYPE=Release \
+	    -DMDV_PACKAGE_OUTPUT_DIR=$(CURDIR)/$(DIST_DIR) $(PREFIX_FLAG)
+	cmake --build $(RELEASE_DIR) --target package_nsis

--- a/Makefile.dist.windows
+++ b/Makefile.dist.windows
@@ -8,7 +8,10 @@
 #
 # The installer offers the user a choice between per-user (no admin, install
 # to %LOCALAPPDATA%\Programs\mdv) and per-machine (admin, Program Files\mdv)
-# via NSIS MultiUser.nsh. Shortcuts and registry hive follow that choice.
+# via a custom nsDialogs page + ExecShell "runas" — NOT NSIS's MultiUser.nsh,
+# whose Highest mode triggers UAC at launch and Standard never elevates.
+# See cmake/mdv.nsi.in for the rationale. Shortcuts + registry hive follow
+# the user's choice.
 #
 # Prereqs:
 #   - NSIS 3.x (makensis.exe) — `choco install nsis` or install from

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -1,32 +1,34 @@
-# CPack configuration — builds .deb and .rpm from the very same install()
-# rules the `make install` path uses (the binary, the .desktop launcher, and
-# the icon). Linux-only for now; Windows/macOS packaging will get their own
-# story when we cross those bridges.
+# CPack configuration — builds the OS-native installer from the very same
+# install() rules `make install` uses (binary + runtime deps + desktop bits).
+# Linux today produces .deb / .rpm; Windows produces an NSIS .exe installer.
+# macOS will follow its own (non-CPack) path; see work/macos-packaging.md.
 #
-# Driven from the Makefile (see Makefile.dist.linux):
-#     make deb    → dist/mdv_<version>_<arch>.deb
-#     make rpm    → dist/mdv-<version>-1.<arch>.rpm
-#     make dist   → both
+# Driven from the per-host Makefile.dist.* include:
+#     Linux:   make deb / make rpm / make dist
+#     Windows: make exe / make dist  (NSIS)
 #
 # This file is include()d at the very end of CMakeLists.txt, AFTER the install()
 # rules — CPack snapshots those rules, so whatever `make install` would lay down
 # is exactly what lands inside the packages.
+
+# Common metadata. Both per-OS branches reuse these; keeps the package's
+# name/version/vendor/contact consistent across formats.
+set(CPACK_PACKAGE_NAME mdv)
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${PROJECT_DESCRIPTION}")
+set(CPACK_PACKAGE_DESCRIPTION
+    "mdv is a fast, offline desktop viewer for Markdown files, with syntax-\
+highlighted code blocks and themeable rendering.")
+set(CPACK_PACKAGE_VENDOR gesslar)
+set(CPACK_PACKAGE_CONTACT "Brian M. Workman <bmw@gesslar.dev>")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/gesslar/mdv.qt")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE.txt")
 
 if(UNIX AND NOT APPLE)
     # Packages install under /usr (not CMake's /usr/local default) so the binary
     # is /usr/bin/mdv and the .desktop/icon sit at the standard XDG paths the
     # desktop environment actually scans.
     set(CPACK_PACKAGING_INSTALL_PREFIX /usr)
-
-    set(CPACK_PACKAGE_NAME mdv)
-    set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
-    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "${PROJECT_DESCRIPTION}")
-    set(CPACK_PACKAGE_DESCRIPTION
-        "mdv is a fast, offline desktop viewer for Markdown files, with syntax-\
-highlighted code blocks and themeable rendering.")
-    set(CPACK_PACKAGE_VENDOR gesslar)
-    set(CPACK_PACKAGE_CONTACT "Brian M. Workman <bmw@gesslar.dev>")
-    set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/gesslar/mdv.qt")
 
     # --- Debian (.deb) --------------------------------------------------------
     #
@@ -56,4 +58,69 @@ highlighted code blocks and themeable rendering.")
     set(CPACK_RPM_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION}")
 
     include(CPack)
+endif()
+
+if(WIN32)
+    # No CPack on Windows. CPack's bundled NSIS template hard-codes
+    # `RequestExecutionLevel admin`, which means every install asks for UAC
+    # whether the user wants a per-user install or not. We want the user to
+    # *choose* between per-user (no admin, AppData) and per-machine (admin,
+    # Program Files) via NSIS's MultiUser.nsh — same posture electron-builder
+    # exposes with oneClick:false + allowElevation:true. CPack's template
+    # isn't parameterisable enough to layer that on, so we drive makensis
+    # directly against our own slim cmake/mdv.nsi.in template.
+    #
+    # Pipeline:
+    #   1. cmake --install $RELEASE_DIR --prefix <stage>
+    #      → stages mdv.exe + Qt runtime + plugins + icon under <stage>
+    #        using the install() rules in the main CMakeLists.txt
+    #   2. configure_file(cmake/mdv.nsi.in build/mdv.nsi)
+    #      → bakes PROJECT_VERSION / vendor / homepage etc. into the script
+    #   3. makensis -DSTAGE_DIR=<stage> -DOUTFILE=<artifact> build/mdv.nsi
+    #      → produces the .exe
+    #
+    # The package_nsis target wires all three into a single cmake --build
+    # invocation. Driven from Makefile.dist.windows.
+    find_program(MAKENSIS_EXECUTABLE makensis
+        HINTS "$ENV{ProgramFiles\(x86\)}/NSIS" "$ENV{ProgramFiles}/NSIS"
+        PATH_SUFFIXES Bin)
+    if(NOT MAKENSIS_EXECUTABLE)
+        message(WARNING
+            "makensis not found — `make exe` will fail. Install NSIS 3.x "
+            "(choco install nsis) and ensure NSIS\\Bin is on PATH.")
+    endif()
+
+    set(MDV_NSIS_TEMPLATE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/mdv.nsi.in")
+    set(MDV_NSIS_SCRIPT   "${CMAKE_BINARY_DIR}/mdv.nsi")
+    set(MDV_NSIS_STAGE    "${CMAKE_BINARY_DIR}/_nsi_stage")
+    # MDV_PACKAGE_OUTPUT_DIR is set by Makefile.dist.windows to the project's
+    # DIST_DIR (dist/). Default to the build dir so manual cmake --build
+    # invocations land somewhere sensible.
+    if(NOT MDV_PACKAGE_OUTPUT_DIR)
+        set(MDV_PACKAGE_OUTPUT_DIR "${CMAKE_BINARY_DIR}")
+    endif()
+    set(MDV_PACKAGE_FILE
+        "${MDV_PACKAGE_OUTPUT_DIR}/mdv-${PROJECT_VERSION}-win64.exe")
+
+    # The .ico and license paths get baked into the script. configure_file()
+    # writes the .nsi at configure time; cache invalidation is automatic when
+    # the .in template or any @VAR@ changes.
+    set(MDV_ICON_PATH    "${CMAKE_SOURCE_DIR}/resources/icons/mdv.ico")
+    set(MDV_LICENSE_PATH "${CMAKE_SOURCE_DIR}/LICENSE.txt")
+    configure_file("${MDV_NSIS_TEMPLATE}" "${MDV_NSIS_SCRIPT}" @ONLY)
+
+    add_custom_target(package_nsis
+        # Wipe-and-fill the staging dir so leftover files from a previous run
+        # don't sneak into the installer.
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${MDV_NSIS_STAGE}"
+        COMMAND ${CMAKE_COMMAND} --install "${CMAKE_BINARY_DIR}"
+                --prefix "${MDV_NSIS_STAGE}" --config Release
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${MDV_PACKAGE_OUTPUT_DIR}"
+        COMMAND "${MAKENSIS_EXECUTABLE}"
+                "-DSTAGE_DIR=${MDV_NSIS_STAGE}"
+                "-DOUTFILE=${MDV_PACKAGE_FILE}"
+                "${MDV_NSIS_SCRIPT}"
+        DEPENDS mdv
+        COMMENT "Packaging mdv ${PROJECT_VERSION} as NSIS installer"
+        VERBATIM)
 endif()

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -81,8 +81,19 @@ if(WIN32)
     #
     # The package_nsis target wires all three into a single cmake --build
     # invocation. Driven from Makefile.dist.windows.
+    # NSIS's installer registers its prefix at HKLM\SOFTWARE\NSIS (default
+    # value, e.g. "C:\Program Files (x86)\NSIS"). Reading the registry is
+    # both more robust than guessing Program Files and sidesteps the env-var-
+    # with-parens problem: $ENV{ProgramFiles(x86)} is a CMP0053-NEW syntax
+    # error (raw `(` and `)` aren't valid in a variable name), and writing
+    # $ENV{ProgramFiles\(x86\)} works but reads oddly enough that Greptile
+    # flagged it on PR #11. The plain $ENV{ProgramFiles} hint stays as a
+    # fallback in case NSIS was installed without writing the registry key.
     find_program(MAKENSIS_EXECUTABLE makensis
-        HINTS "$ENV{ProgramFiles\(x86\)}/NSIS" "$ENV{ProgramFiles}/NSIS"
+        HINTS
+            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\NSIS]"
+            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\WOW6432Node\\NSIS]"
+            "$ENV{ProgramFiles}/NSIS"
         PATH_SUFFIXES Bin)
     if(NOT MAKENSIS_EXECUTABLE)
         message(WARNING

--- a/cmake/mdv.nsi.in
+++ b/cmake/mdv.nsi.in
@@ -1,0 +1,292 @@
+; mdv NSIS installer template — configured by CMake via @VAR@ substitution.
+;
+; Goal: match electron-builder's `oneClick:false + allowElevation:true`
+; behaviour. The installer starts UNPRIVILEGED, the user sees a wizard page
+; asking per-user vs per-machine, and UAC only appears if they pick
+; per-machine and aren't already an admin.
+;
+; Why not stock NSIS MultiUser.nsh: its `Highest` execution level triggers
+; UAC at launch — before the user even sees the choice. Its `Standard` level
+; never elevates. Neither is "elevate only if needed", which is what we want.
+; The third-party NsisMultiUser plugin handles this but adds a ~750-line
+; vendored dependency. Hand-rolling it is ~50 extra lines and keeps the
+; script self-contained.
+;
+; CMake feeds two -D defines:
+;   STAGE_DIR — the staged install tree (mdv.exe + Qt runtime, laid down by
+;               `cmake --install`) that File /r packages into the installer
+;   OUTFILE   — the path to write the resulting installer .exe to
+
+Unicode true
+SetCompressor /SOLID lzma
+
+!define APPNAME       "mdv"
+!define VERSION       "@PROJECT_VERSION@"
+!define COMPANY       "@CPACK_PACKAGE_VENDOR@"
+!define HOMEPAGE      "@CPACK_PACKAGE_HOMEPAGE_URL@"
+!define CONTACT       "@CPACK_PACKAGE_CONTACT@"
+; mdv.exe lives under $INSTDIR\bin (don't end this comment with a backslash —
+; NSIS would treat the trailing \ as a line-continuation and swallow the next
+; !define).
+!define MAINEXE       "mdv.exe"
+!define PROGID        "mdv.markdown"
+!define UNINSTKEY     "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
+
+; Start the process unprivileged. We trigger UAC manually further down if
+; the user picks per-machine on the install-mode page.
+RequestExecutionLevel user
+
+!include "MUI2.nsh"
+!include "LogicLib.nsh"
+!include "nsDialogs.nsh"
+!include "FileFunc.nsh"
+!include "WinMessages.nsh"
+
+Name "${APPNAME}"
+OutFile "${OUTFILE}"
+BrandingText "${APPNAME} ${VERSION}"
+ShowInstDetails show
+ShowUninstDetails show
+
+; --- State -----------------------------------------------------------------
+; $InstallMode: "current" or "all". Drives $INSTDIR default, SetShellVarContext
+; (and therefore SHCTX), shortcut placement, and which Uninstall hive owns
+; the Add/Remove Programs entry.
+Var InstallMode
+Var IsAdmin
+
+; Custom-page dialog handles (kept across page show/leave callbacks).
+Var ScopeDlg
+Var RadioCurrent
+Var RadioAll
+
+; --- UI --------------------------------------------------------------------
+!define MUI_ICON   "@MDV_ICON_PATH@"
+!define MUI_UNICON "@MDV_ICON_PATH@"
+!define MUI_ABORTWARNING
+
+!insertmacro MUI_PAGE_LICENSE "@MDV_LICENSE_PATH@"
+Page custom ScopePage ScopePageLeave    ; per-user vs per-machine
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+!insertmacro MUI_LANGUAGE "English"
+
+; --- Init ------------------------------------------------------------------
+; Runs before the first page. Detects whether we're already admin (so the
+; mode page can skip the relaunch dance for per-machine), parses /AllUsers
+; or /CurrentUser flags that the *relaunched* instance carries, and falls
+; back to per-user defaults otherwise.
+Function .onInit
+  UserInfo::GetAccountType
+  Pop $0
+  ${If} $0 == "Admin"
+    StrCpy $IsAdmin "1"
+  ${Else}
+    StrCpy $IsAdmin "0"
+  ${EndIf}
+
+  ${GetParameters} $R0
+
+  ClearErrors
+  ${GetOptions} $R0 "/AllUsers" $R1
+  ${IfNot} ${Errors}
+    StrCpy $InstallMode "all"
+    StrCpy $INSTDIR "$PROGRAMFILES64\${APPNAME}"
+    SetShellVarContext all
+    Return
+  ${EndIf}
+
+  ClearErrors
+  ${GetOptions} $R0 "/CurrentUser" $R1
+  ${IfNot} ${Errors}
+    StrCpy $InstallMode "current"
+    StrCpy $INSTDIR "$LOCALAPPDATA\Programs\${APPNAME}"
+    SetShellVarContext current
+    Return
+  ${EndIf}
+
+  ; Default: per-user, no elevation.
+  StrCpy $InstallMode "current"
+  StrCpy $INSTDIR "$LOCALAPPDATA\Programs\${APPNAME}"
+  SetShellVarContext current
+FunctionEnd
+
+; --- Install-mode page -----------------------------------------------------
+Function ScopePage
+  ; When the installer is relaunched with /AllUsers or /CurrentUser the user
+  ; has already picked — skip the page so the elevated instance doesn't ask
+  ; the same question again.
+  ${GetParameters} $R0
+  ClearErrors
+  ${GetOptions} $R0 "/AllUsers" $R1
+  ${IfNot} ${Errors}
+    Abort
+  ${EndIf}
+  ClearErrors
+  ${GetOptions} $R0 "/CurrentUser" $R1
+  ${IfNot} ${Errors}
+    Abort
+  ${EndIf}
+
+  !insertmacro MUI_HEADER_TEXT "Choose Installation Type" "For whom should ${APPNAME} be installed?"
+
+  nsDialogs::Create 1018
+  Pop $ScopeDlg
+  ${If} $ScopeDlg == error
+    Abort
+  ${EndIf}
+
+  ${NSD_CreateRadioButton} 0 0 100% 12u "Install for &me only (no admin required)"
+  Pop $RadioCurrent
+  ${NSD_CreateLabel}       15u 14u 100% 18u "Installs to your AppData. Doesn't affect other users on this PC."
+  Pop $0
+
+  ${NSD_CreateRadioButton} 0 40u 100% 12u "Install for &all users (requires admin)"
+  Pop $RadioAll
+  ${NSD_CreateLabel}       15u 54u 100% 18u "Installs to Program Files. Windows will ask you to approve a UAC prompt."
+  Pop $0
+
+  ${If} $InstallMode == "all"
+    ${NSD_SetState} $RadioAll ${BST_CHECKED}
+  ${Else}
+    ${NSD_SetState} $RadioCurrent ${BST_CHECKED}
+  ${EndIf}
+
+  nsDialogs::Show
+FunctionEnd
+
+Function ScopePageLeave
+  ${NSD_GetState} $RadioAll $0
+  ${If} $0 == ${BST_CHECKED}
+    StrCpy $InstallMode "all"
+    StrCpy $INSTDIR "$PROGRAMFILES64\${APPNAME}"
+    SetShellVarContext all
+
+    ; Per-machine + already admin → continue in this process. Per-machine +
+    ; standard user → relaunch ourselves with `runas`, which is what triggers
+    ; the UAC prompt. The elevated instance picks up the /AllUsers flag in
+    ; its .onInit and skips this page.
+    ${If} $IsAdmin == "0"
+      HideWindow
+      ExecShell "runas" "$EXEPATH" "/AllUsers"
+      ; Whether UAC was accepted (a new elevated instance is now running) or
+      ; cancelled (nothing happened), this user-mode instance is done.
+      Quit
+    ${EndIf}
+  ${Else}
+    StrCpy $InstallMode "current"
+    StrCpy $INSTDIR "$LOCALAPPDATA\Programs\${APPNAME}"
+    SetShellVarContext current
+  ${EndIf}
+FunctionEnd
+
+; --- Install ---------------------------------------------------------------
+; SHCTX resolves to HKLM when shell context is `all`, HKCU when `current` —
+; so file associations, shortcuts and the Add/Remove Programs entry land in
+; the right hive automatically.
+Section "Install"
+  SetOutPath "$INSTDIR"
+  File /r "${STAGE_DIR}\*.*"
+
+  WriteRegStr SHCTX "Software\Classes\.md"                              "" "${PROGID}"
+  WriteRegStr SHCTX "Software\Classes\.markdown"                        "" "${PROGID}"
+  WriteRegStr SHCTX "Software\Classes\.mkd"                             "" "${PROGID}"
+  WriteRegStr SHCTX "Software\Classes\${PROGID}"                        "" "Markdown document"
+  WriteRegStr SHCTX "Software\Classes\${PROGID}\DefaultIcon"            "" "$INSTDIR\bin\${MAINEXE},0"
+  WriteRegStr SHCTX "Software\Classes\${PROGID}\shell\open\command"     "" '$\"$INSTDIR\bin\${MAINEXE}$\" $\"%1$\"'
+
+  CreateShortcut "$SMPROGRAMS\${APPNAME}.lnk" "$INSTDIR\bin\${MAINEXE}"
+  CreateShortcut "$DESKTOP\${APPNAME}.lnk"    "$INSTDIR\bin\${MAINEXE}"
+
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
+  ; The /AllUsers /CurrentUser flag on the uninstall command lets un.onInit
+  ; pick the same hive at uninstall time without re-guessing from $INSTDIR.
+  StrCpy $0 "/CurrentUser"
+  ${If} $InstallMode == "all"
+    StrCpy $0 "/AllUsers"
+  ${EndIf}
+  WriteRegStr SHCTX "${UNINSTKEY}" "DisplayName"           "${APPNAME}"
+  WriteRegStr SHCTX "${UNINSTKEY}" "DisplayVersion"        "${VERSION}"
+  WriteRegStr SHCTX "${UNINSTKEY}" "DisplayIcon"           "$INSTDIR\bin\${MAINEXE}"
+  WriteRegStr SHCTX "${UNINSTKEY}" "Publisher"             "${COMPANY}"
+  WriteRegStr SHCTX "${UNINSTKEY}" "URLInfoAbout"          "${HOMEPAGE}"
+  WriteRegStr SHCTX "${UNINSTKEY}" "Contact"               "${CONTACT}"
+  WriteRegStr SHCTX "${UNINSTKEY}" "InstallLocation"       "$INSTDIR"
+  WriteRegStr SHCTX "${UNINSTKEY}" "UninstallString"       '$\"$INSTDIR\Uninstall.exe$\" $0'
+  WriteRegStr SHCTX "${UNINSTKEY}" "QuietUninstallString"  '$\"$INSTDIR\Uninstall.exe$\" /S $0'
+  WriteRegDWORD SHCTX "${UNINSTKEY}" "NoModify" 1
+  WriteRegDWORD SHCTX "${UNINSTKEY}" "NoRepair" 1
+
+  System::Call 'Shell32::SHChangeNotify(i 0x08000000, i 0, i 0, i 0)'
+SectionEnd
+
+; --- Uninstall init --------------------------------------------------------
+; Same flag-driven mode detection as the installer side, with a fallback to
+; check whether the install dir starts with $PROGRAMFILES64 (per-machine) or
+; $LOCALAPPDATA (per-user) when the flag is missing — e.g. if someone runs
+; Uninstall.exe directly from Explorer.
+Function un.onInit
+  UserInfo::GetAccountType
+  Pop $0
+  ${If} $0 == "Admin"
+    StrCpy $IsAdmin "1"
+  ${Else}
+    StrCpy $IsAdmin "0"
+  ${EndIf}
+
+  ${GetParameters} $R0
+
+  ClearErrors
+  ${GetOptions} $R0 "/AllUsers" $R1
+  ${IfNot} ${Errors}
+    StrCpy $InstallMode "all"
+    SetShellVarContext all
+    ; Re-elevate ourselves if a non-admin double-clicks the per-machine
+    ; uninstaller. Same dance as the installer side.
+    ${If} $IsAdmin == "0"
+      HideWindow
+      ExecShell "runas" "$EXEPATH" "/AllUsers _?=$INSTDIR"
+      Quit
+    ${EndIf}
+    Return
+  ${EndIf}
+  ClearErrors
+  ${GetOptions} $R0 "/CurrentUser" $R1
+  ${IfNot} ${Errors}
+    StrCpy $InstallMode "current"
+    SetShellVarContext current
+    Return
+  ${EndIf}
+
+  ; Fallback: infer from $INSTDIR. NSIS sets $INSTDIR to the uninstaller's
+  ; own location at startup, so this is reliable.
+  StrCpy $0 "$INSTDIR" 4
+  ${If} "$0" == "$PROGRAMFILES64"
+    StrCpy $InstallMode "all"
+    SetShellVarContext all
+  ${Else}
+    StrCpy $InstallMode "current"
+    SetShellVarContext current
+  ${EndIf}
+FunctionEnd
+
+; --- Uninstall -------------------------------------------------------------
+Section "Uninstall"
+  Delete "$SMPROGRAMS\${APPNAME}.lnk"
+  Delete "$DESKTOP\${APPNAME}.lnk"
+
+  DeleteRegKey SHCTX "Software\Classes\.md"
+  DeleteRegKey SHCTX "Software\Classes\.markdown"
+  DeleteRegKey SHCTX "Software\Classes\.mkd"
+  DeleteRegKey SHCTX "Software\Classes\${PROGID}"
+  DeleteRegKey SHCTX "${UNINSTKEY}"
+
+  RMDir /r "$INSTDIR"
+
+  System::Call 'Shell32::SHChangeNotify(i 0x08000000, i 0, i 0, i 0)'
+SectionEnd

--- a/cmake/mdv.nsi.in
+++ b/cmake/mdv.nsi.in
@@ -265,7 +265,15 @@ Function un.onInit
 
   ; Fallback: infer from $INSTDIR. NSIS sets $INSTDIR to the uninstaller's
   ; own location at startup, so this is reliable.
-  StrCpy $0 "$INSTDIR" 4
+  ;
+  ; StrCpy's third arg is `maxlen` — we want to grab the first N chars of
+  ; $INSTDIR where N == length($PROGRAMFILES64), then compare. The earlier
+  ; hard-coded `4` was a bug: copying only "C:\P" then comparing against
+  ; the full "C:\Program Files" string was always false, so per-machine
+  ; uninstalls launched directly from Explorer landed in HKCU and stranded
+  ; the real HKLM entries. (Caught by Greptile on PR #11.)
+  StrLen $1 "$PROGRAMFILES64"
+  StrCpy $0 "$INSTDIR" $1
   ${If} "$0" == "$PROGRAMFILES64"
     StrCpy $InstallMode "all"
     SetShellVarContext all

--- a/cmake/mdv.nsi.in
+++ b/cmake/mdv.nsi.in
@@ -288,11 +288,23 @@ Section "Uninstall"
   Delete "$SMPROGRAMS\${APPNAME}.lnk"
   Delete "$DESKTOP\${APPNAME}.lnk"
 
-  DeleteRegKey SHCTX "Software\Classes\.md"
-  DeleteRegKey SHCTX "Software\Classes\.markdown"
-  DeleteRegKey SHCTX "Software\Classes\.mkd"
-  DeleteRegKey SHCTX "Software\Classes\${PROGID}"
-  DeleteRegKey SHCTX "${UNINSTKEY}"
+  ; Extension keys: only delete the (Default) value we wrote, then drop the
+  ; whole key if nothing else is left under it. Other apps (and Windows
+  ; itself) may have added subkeys like OpenWithProgids / OpenWithList /
+  ; PerceivedType over time — nuking the entire .md key on uninstall would
+  ; silently throw all of that away, which is especially bad in HKLM where
+  ; it affects every user on the machine. (Caught by Greptile on PR #11.)
+  ;
+  ; The ProgID key (mdv.markdown) is ours top-to-bottom — safe to remove
+  ; whole. Same for the Uninstall registration.
+  DeleteRegValue        SHCTX "Software\Classes\.md"        ""
+  DeleteRegKey /ifempty SHCTX "Software\Classes\.md"
+  DeleteRegValue        SHCTX "Software\Classes\.markdown"  ""
+  DeleteRegKey /ifempty SHCTX "Software\Classes\.markdown"
+  DeleteRegValue        SHCTX "Software\Classes\.mkd"       ""
+  DeleteRegKey /ifempty SHCTX "Software\Classes\.mkd"
+  DeleteRegKey          SHCTX "Software\Classes\${PROGID}"
+  DeleteRegKey          SHCTX "${UNINSTKEY}"
 
   RMDir /r "$INSTDIR"
 

--- a/resources/mdv.rc
+++ b/resources/mdv.rc
@@ -1,0 +1,12 @@
+// Windows resource script. Embeds mdv.ico into mdv.exe so Explorer, the
+// taskbar, Start Menu shortcuts, and the Apps & Features (Add/Remove
+// Programs) entry all show the app icon — without an icon resource here,
+// they fall back to the generic "default exe" icon. Compiled by windres
+// (MinGW) or rc.exe (MSVC); CMake wires it in via target_sources() in
+// the if(WIN32) block of CMakeLists.txt.
+//
+// Resource ID 1 is the convention Explorer's icon extractor (ExtractIconEx
+// index 0) looks for first, so this is what NSIS shortcuts and the
+// DisplayIcon registry value pick up automatically when they reference
+// mdv.exe.
+1 ICON "icons/mdv.ico"


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds complete Windows build and packaging support: FetchContent for md4c, extra-cmake-modules, and KSyntaxHighlighting (removing the KDE Craft requirement), plus a custom NSIS-based installer with per-user/per-machine installation choice without forcing UAC at launch.

- **CMakeLists.txt** adds a Windows-only `install()` override gate so FetchContent subprojects (md4c, ECM, KSH) don't bake their install rules into the final NSIS package; the gate flips ON only for mdv's own install rules.
- **cmake/mdv.nsi.in** is a new self-contained NSIS script implementing the per-user vs per-machine choice via `nsDialogs` + `ExecShell \"runas\"` (not MultiUser.nsh); the fallback hive-detection in `un.onInit` that was broken in the previous review iteration is correctly fixed using `StrLen`/`StrCpy` against `$PROGRAMFILES64`.
- **cmake/Packaging.cmake** gains a `WIN32` branch with a `package_nsis` custom target; the previous `CPACK_*` metadata is moved to a shared block reused by both Linux and Windows paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the Windows build path is self-contained and the previously reported uninstaller hive-detection bug is correctly fixed.

The install() gate mechanism, ECM bootstrap, NSIS elevation dance, and registry cleanup are all implemented correctly. The un.onInit fallback now uses StrLen + StrCpy to extract the right number of chars from $INSTDIR before comparing against $PROGRAMFILES64, closing the bug from the previous review. No functional issues remain in the changed files.

No files require special attention.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acmake%2FPackaging.cmake%3A66-71%0A**Misleading%20reference%20to%20MultiUser.nsh**%0A%0AThe%20phrase%20%22via%20NSIS's%20MultiUser.nsh%22%20reads%20as%20if%20the%20plugin%20is%20actually%20used%20here%2C%20but%20%60cmake%2Fmdv.nsi.in%60%20explicitly%20avoids%20it%20%28and%20explains%20why%20at%20the%20top%20of%20that%20file%29.%20A%20future%20editor%20auditing%20the%20%60.nsi%60%20file%20would%20wonder%20where%20MultiUser.nsh%20went.%20Consider%20rephrasing%20to%20%22the%20same%20posture%20as%20MultiUser.nsh's%20%60Highest%60%20mode%2C%20but%20without%20using%20it%22%20to%20make%20the%20intent%20clear%20without%20implying%20the%20plugin%20is%20in%20the%20dependency%20chain.%0A%0A&repo=gesslar%2Fmdv.qt&pr=11&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["nsis: locate makensis via the registry i..."](https://github.com/gesslar/mdv.qt/commit/a6575de8e5e3aae9c45fe35bda2ac483f6c6fe32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33778545)</sub>

<!-- /greptile_comment -->