### PR TITLE
flatpak build support

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -132,6 +132,35 @@ soname packages, which are the wrong names for a `.deb`. Keep it in step with
 the link line if you add a library. RPM `Requires:` are auto-detected by
 `rpmbuild`.
 
+### Flatpak
+
+A single-file `.flatpak` is built with `flatpak-builder` against the KDE runtime
+(`org.kde.Platform` 6.9), which already ships Qt 6 and KSyntaxHighlighting — so
+only md4c is built alongside mdv. The manifest `dev.gesslar.mdv.yml` builds
+straight from this checkout (no pushed tag required).
+
+```bash
+make flatpak   # → dist/mdv-<version>-<arch>.flatpak
+```
+
+**Tooling** (packaging dep, not a build dep): `flatpak` + `flatpak-builder`, with
+the flathub remote configured:
+
+- Fedora: `sudo dnf install flatpak flatpak-builder`
+- Debian/Ubuntu: `sudo apt install flatpak flatpak-builder`
+- `flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo`
+
+The first `make flatpak` pulls `org.kde.Platform` / `org.kde.Sdk` 6.9 (a large
+one-time download). Install and run the bundle with:
+
+```bash
+flatpak install --user dist/mdv-*.flatpak   # e.g. mdv-2.0.0-x86_64.flatpak
+flatpak run dev.gesslar.mdv                 # run/install are by app-id, not filename
+```
+
+For a Flathub submission, repoint the `mdv` module source from this local
+checkout to a pinned remote (url + tag + commit).
+
 macOS will get its own `Makefile.dist.macos` include when that build path is
 ready.
 

--- a/Makefile.dist.linux
+++ b/Makefile.dist.linux
@@ -2,17 +2,19 @@
 # on Linux. Produces .deb and .rpm via CPack against the release build; the
 # package metadata (deps, license, sections) lives in cmake/Packaging.cmake.
 #
-#     make deb    → dist/mdv_<version>_<arch>.deb
-#     make rpm    → dist/mdv-<version>-1.<arch>.rpm
-#     make dist   → both
+#     make deb     → dist/mdv_<version>_<arch>.deb
+#     make rpm     → dist/mdv-<version>-1.<arch>.rpm
+#     make dist    → both
+#     make flatpak → dist/mdv-<version>-<arch>.flatpak (KDE runtime; pulls the SDK once)
 #
-# A .deb needs dpkg-deb on PATH; a .rpm needs rpmbuild. See DEVELOPMENT.md for
-# how to install them (they're not build deps — only packaging deps).
+# A .deb needs dpkg-deb on PATH; a .rpm needs rpmbuild; a .flatpak needs flatpak
+# + flatpak-builder. See DEVELOPMENT.md for how to install them (they're not
+# build deps — only packaging deps).
 #
 # DIST_DIR (the output directory) comes from the top-level Makefile, alongside
 # DEV_DIR / RELEASE_DIR, so `make distclean` there can sweep it too.
 
-.PHONY: dist deb rpm
+.PHONY: dist deb rpm flatpak
 
 # Every Linux package format.
 dist: deb rpm
@@ -25,3 +27,28 @@ deb: release
 
 rpm: release
 	cpack --config $(RELEASE_DIR)/CPackConfig.cmake -G RPM -B $(DIST_DIR)
+
+# The bundle filename carries version + arch (like the .deb/.rpm) so a download
+# is identifiable instead of a bare app-id. Version comes from project(VERSION)
+# in CMakeLists.txt — the single source; arch from flatpak. (The app-id
+# "dev.gesslar.mdv" is the identity INSIDE the bundle; the filename is for humans.)
+# Lazy `=` (not `:=`): these shell out, so deferring expansion keeps a plain
+# `make build` (and CI, and flatpak-less hosts) from forking sed + flatpak on
+# every run — they fire only when the flatpak target below expands them. Each is
+# referenced once, so there's no re-eval cost.
+MDV_VERSION = $(shell sed -nE 's/^[[:space:]]*VERSION[[:space:]]+([0-9.]+).*/\1/p' CMakeLists.txt | head -1)
+MDV_ARCH    = $(shell flatpak --default-arch 2>/dev/null || uname -m)
+
+# Flatpak: build mdv against the KDE runtime via flatpak-builder, then bundle a
+# single-file dist/mdv-<version>-<arch>.flatpak. --install-deps-from=flathub
+# pulls the runtime + SDK on first run (a large one-time download). Independent
+# of the CPack path above — flatpak-builder builds its own copy of mdv in the
+# sandbox from dev.gesslar.mdv.yml. Deliberately NOT part of `dist`, so a routine
+# `make dist` doesn't trigger the SDK download. See DEVELOPMENT.md.
+flatpak:
+	flatpak-builder --force-clean --user --install-deps-from=flathub \
+	  --state-dir=$(DIST_DIR)/.flatpak-builder \
+	  --repo=$(DIST_DIR)/flatpak-repo \
+	  $(DIST_DIR)/flatpak-build dev.gesslar.mdv.yml
+	flatpak build-bundle $(DIST_DIR)/flatpak-repo \
+	  $(DIST_DIR)/mdv-$(MDV_VERSION)-$(MDV_ARCH).flatpak dev.gesslar.mdv

--- a/dev.gesslar.mdv.yml
+++ b/dev.gesslar.mdv.yml
@@ -1,0 +1,68 @@
+# Flatpak manifest for mdv. Build + bundle with `make flatpak` (a thin wrapper
+# around flatpak-builder — see Makefile.dist.linux / DEVELOPMENT.md).
+#
+# Self-contained: the `mdv` module builds straight from THIS repo's working tree
+# (type: dir, path: .) — no presumed pushed tag or sibling directory. The KDE
+# runtime already ships Qt 6 and KSyntaxHighlighting (KF6), so the only thing we
+# build alongside mdv is md4c, the one genuinely-external dependency.
+#
+# For a Flathub submission, swap the mdv source to a pinned remote
+# (type: git with url + tag + commit) — Flathub builds from a published ref,
+# not a local checkout.
+id: dev.gesslar.mdv
+runtime: org.kde.Platform
+runtime-version: '6.9'
+sdk: org.kde.Sdk
+command: mdv
+
+finish-args:
+  - --share=ipc
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  # Read-only access to the host: a file opened via CLI args or drag-and-drop
+  # resolves from anywhere on disk. A viewer never writes, so :ro is the whole
+  # story. (Flathub may prefer portal-only; tighten here if so.)
+  - --filesystem=host:ro
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /lib/cmake
+  - '*.a'
+
+modules:
+  # Third-party Markdown parser — the one external source, pinned upstream.
+  - name: md4c
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+    sources:
+      - type: git
+        url: https://github.com/mity/md4c.git
+        tag: release-0.5.3
+        # Pin the commit too — a tag is mutable; this locks the source to a SHA.
+        commit: 472c417005c2c71b8617de4f7b8d6b30411d78f4
+    cleanup:
+      - /bin   # the md2html demo CLI; we only link libmd4c-html
+
+  # mdv itself, from this repo. Our install() rules already lay down the binary,
+  # the .desktop, the AppStream metainfo, and the icon under /app/share — so
+  # there's nothing extra to hand-install here.
+  - name: mdv
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+    sources:
+      - type: dir
+        path: .
+        # .git is deliberately NOT skipped: the build derives the AppStream
+        # release date from `git log` (see CMakeLists.txt), so the sandbox
+        # metainfo carries the same commit date as the deb/rpm build instead of
+        # falling back to a build timestamp.
+        skip:
+          - build
+          - build-release
+          - dist
+          - .flatpak-builder


### PR DESCRIPTION
## Add Flatpak packaging support

Introduces a `make flatpak` target that builds `mdv` against the KDE runtime (`org.kde.Platform` 6.9) using `flatpak-builder`, producing a self-contained `dist/dev.gesslar.mdv.flatpak` bundle.

The new `dev.gesslar.mdv.yml` manifest builds directly from the local working tree, requiring no pushed tag or remote source. Since the KDE runtime already ships Qt 6 and KSyntaxHighlighting, only `md4c` is compiled as an additional module. The `--filesystem=host:ro` finish arg allows the viewer to open files from anywhere on disk without write access.

The `flatpak` target is intentionally excluded from `make dist` to avoid triggering the one-time KDE SDK download during routine packaging builds.

`DEVELOPMENT.md` documents the required tooling (`flatpak` + `flatpak-builder` with the Flathub remote), the first-run SDK download behaviour, and how to install and run the resulting bundle. It also notes the source change needed for a future Flathub submission.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `make flatpak` target that builds `mdv` inside a KDE 6.9 sandbox via `flatpak-builder`, producing a self-contained `dist/mdv-<version>-<arch>.flatpak` bundle. The manifest compiles only `md4c` as an external module (KDE runtime ships Qt 6 and KSyntaxHighlighting), sources the app straight from the local working tree, and keeps the target outside `make dist` to avoid a large one-time SDK download on routine packaging builds.

- **`dev.gesslar.mdv.yml`**: New Flatpak manifest; permissions are minimal (`--filesystem=host:ro` for read-only file access, Wayland/X11 sockets, DRI device); `md4c` is pinned to both a tag and a commit SHA; `.git` is deliberately included so CMake can derive the AppStream release date from `git log`.
- **`Makefile.dist.linux`**: New `flatpak` target with lazy `=` variable expansion for `MDV_VERSION` (extracted from `CMakeLists.txt` via `sed`) and `MDV_ARCH` (from `flatpak --default-arch` with a `uname -m` fallback), keeping a plain `make build` fast on flatpak-less hosts.
- **`DEVELOPMENT.md`**: Documents required tooling, first-run SDK download behaviour, install/run workflow, and the source change needed for a future Flathub submission.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are additive packaging infrastructure that does not touch the application source or any existing build path.

All three changed files are purely additive: a new manifest, a new Makefile target, and documentation. The existing deb/rpm/dist targets are unchanged. The sed version extraction matches the actual CMakeLists.txt layout, the md4c source is pinned with both a tag and a commit SHA, and the flatpak target is deliberately excluded from make dist to avoid side-effects on CI or flatpak-less hosts.

No files require special attention.

<sub>Reviews (6): Last reviewed commit: ["feat: Flatpak packaging via the KDE runt..."](https://github.com/gesslar/mdv.qt/commit/26275caeec5b771a924ad6ea9db840cf76a7c11e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33843410)</sub>

<!-- /greptile_comment -->