### PR TITLE
appimage support

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -161,6 +161,32 @@ flatpak run dev.gesslar.mdv                 # run/install are by app-id, not fil
 For a Flathub submission, repoint the `mdv` module source from this local
 checkout to a pinned remote (url + tag + commit).
 
+### AppImage
+
+A single-file `.AppImage` is built with `appimagetool`, but the dependency
+deploy is **hand-rolled** (`scripts/appimage.sh`) rather than via linuxdeploy.
+The reason: patchelf — which linuxdeploy uses to stamp each bundled library with
+an `$ORIGIN` RUNPATH — corrupts libraries carrying RELR relocations
+(`.relr.dyn`, which Fedora's toolchain emits by default), so a random lib
+segfaults in `_dl_init` before `main()`. Instead we copy the dependency closure
+**byte-pristine** and resolve it at runtime with a wrapper `AppRun` that sets
+`LD_LIBRARY_PATH` — no ELF is ever rewritten.
+
+```bash
+make appimage   # → dist/mdv-<version>-<arch>.AppImage
+```
+
+**Tooling** (packaging dep, not a build dep): `appimagetool` on `PATH`. Bundled
+libraries exclude the host-provided set per `scripts/excludelist` (the upstream
+AppImage list, kept byte-identical and diffable) plus `scripts/excludelist.mdv`
+(our additions — the systemd/dbus/crypto/network libs Qt drags in that a local
+viewer never needs). `scripts/appdir-lint.sh` (also straight from the AppImage
+project) validates the AppDir against AppImageHub's rules.
+
+> The AppImage is built on the host for now, so its glibc floor is the build
+> host's. A reproducible Fedora build container — building the Flatpak too — is
+> a planned follow-up.
+
 macOS will get its own `Makefile.dist.macos` include when that build path is
 ready.
 

--- a/Makefile.dist.linux
+++ b/Makefile.dist.linux
@@ -2,19 +2,20 @@
 # on Linux. Produces .deb and .rpm via CPack against the release build; the
 # package metadata (deps, license, sections) lives in cmake/Packaging.cmake.
 #
-#     make deb     → dist/mdv_<version>_<arch>.deb
-#     make rpm     → dist/mdv-<version>-1.<arch>.rpm
-#     make dist    → both
-#     make flatpak → dist/mdv-<version>-<arch>.flatpak (KDE runtime; pulls the SDK once)
+#     make deb      → dist/mdv_<version>_<arch>.deb
+#     make rpm      → dist/mdv-<version>-1.<arch>.rpm
+#     make dist     → both
+#     make flatpak  → dist/mdv-<version>-<arch>.flatpak  (KDE runtime; pulls the SDK once)
+#     make appimage → dist/mdv-<version>-<arch>.AppImage (patchelf-free; needs appimagetool)
 #
 # A .deb needs dpkg-deb on PATH; a .rpm needs rpmbuild; a .flatpak needs flatpak
-# + flatpak-builder. See DEVELOPMENT.md for how to install them (they're not
-# build deps — only packaging deps).
+# + flatpak-builder; an .AppImage needs appimagetool. See DEVELOPMENT.md for how
+# to install them (they're not build deps — only packaging deps).
 #
 # DIST_DIR (the output directory) comes from the top-level Makefile, alongside
 # DEV_DIR / RELEASE_DIR, so `make distclean` there can sweep it too.
 
-.PHONY: dist deb rpm flatpak
+.PHONY: dist deb rpm flatpak appimage
 
 # Every Linux package format.
 dist: deb rpm
@@ -52,3 +53,10 @@ flatpak:
 	  $(DIST_DIR)/flatpak-build dev.gesslar.mdv.yml
 	flatpak build-bundle $(DIST_DIR)/flatpak-repo \
 	  $(DIST_DIR)/mdv-$(MDV_VERSION)-$(MDV_ARCH).flatpak dev.gesslar.mdv
+
+# AppImage: a patchelf-free single-file bundle. scripts/appimage.sh hand-rolls
+# the deploy (pristine libs + a wrapper AppRun) because patchelf corrupts this
+# distro's RELR libraries — the script header has the full why. Needs
+# appimagetool on PATH; NOT part of `dist` (its own format).
+appimage: release
+	scripts/appimage.sh

--- a/scripts/appdir-lint.sh
+++ b/scripts/appdir-lint.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+# Checks AppDir for maximum compatibility with AppImage best practices.
+# This might evolve into a more formal specification one day.
+
+set -e
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+APPDIR="${1}"
+
+fatal () {
+  echo "FATAL: $1"
+  exit 1
+}
+
+warn () {
+  echo "WARNING: $1"
+}
+
+which desktop-file-validate >/dev/null
+if [ ! $? -eq 0 ] ; then
+  fatal "desktop-file-validate is missing, please install it"
+fi
+
+if [ ! -e "${HERE}/excludelist" ] ; then
+  fatal "excludelist missing, please install it"
+fi
+
+if [ ! -d "${APPDIR}" ] ; then
+  fatal "${APPDIR} is no directory"
+fi
+
+if [ ! -e "${APPDIR}/AppRun" ] ; then
+  fatal "AppRun is missing in ${APPDIR}"
+fi
+
+if [ ! -e "${APPDIR}/.DirIcon" ] ; then
+  fatal ".DirIcon is missing in ${APPDIR}"
+fi
+
+DIR_ICON_MIME=$(mimetype $(readlink -f ${APPDIR}/.DirIcon) | awk '{print $2}')
+
+if [[  ! "$DIR_ICON_MIME" = "image/png"  ]] ; then
+  warn "Icon is not in PNG format. It should be so that it can be used as a thumbnail"
+fi
+
+if [ ! -x "${APPDIR}/AppRun" ] ; then
+  fatal "AppRun is not executable" // This seems to generate false alarms? https://travis-ci.org/AppImage/AppImageHub/builds/266084511#L539
+fi
+
+NUM_DESKTOP=$(ls "${APPDIR}"/*.desktop 2>/dev/null | wc -l)
+if [ ${NUM_DESKTOP} != 1 ] ; then
+  fatal "No .desktop file or multiple desktop files present"
+fi
+
+num_keys_fatal () {
+  while IFS='=' read key val
+  do
+      if [[ $key == \[*\] ]] ; then
+        # in a new section; confirm we saw the key once in [Desktop Entry]
+        if [[ "${raw_section}" == "[Desktop Entry]" ]] ; then
+          local seen_key="seen__${section}__${1}"
+          if [[ "${!seen_key}" != "1" ]] ; then
+            fatal "Key $1 is not in .desktop file exactly once in section $raw_section"
+          fi
+        fi
+        local raw_section=$key
+        local section="${key//[\[\]\- ]/_}"
+      elif [[ $key == "$1" ]] ; then
+        local seen_key="seen__${section}__${key}"
+        printf -v "$seen_key" %s "$(( $seen_key + 1 ))"
+      fi
+  done < "${APPDIR}"/*.desktop
+
+
+  # in case there is only one section
+  # check for existence of key in [Desktop Entry]
+  local seen_key="seen__${section}__${1}"
+  if [[ "${section}" == "[Desktop Entry]" && "${!seen_key}" != "1" ]] ; then
+    fatal "Key $1 is not in .desktop file exactly once in section $raw_section"
+  fi
+}
+
+desktop-file-validate "${APPDIR}"/*.desktop
+if [ ! $? -eq 0 ] ; then
+  fatal "desktop-file-validate did not exit cleanly on the .desktop file"
+fi
+
+num_keys_warn () {
+  while IFS='=' read key val
+  do
+      if [[ $key == \[*\] ]] ; then
+        # in a new section; confirm we saw the key once in [Desktop Entry]
+        if [[ "${raw_section}" == "[Desktop Entry]" ]] ; then
+          local seen_key="seen__${section}__${1}"
+          if [[ "${!seen_key}" != "1" ]] ; then
+            warn "Key $1 is not in .desktop file exactly once in section $raw_section"
+          fi
+        fi
+        local raw_section=$key
+        local section="${key//[\[\]\- ]/_}"
+      elif [[ $key == "$1" ]] ; then
+        local seen_key="seen__${section}__${key}"
+        printf -v "$seen_key" %s "$(( $seen_key + 1 ))"
+      fi
+  done < "${APPDIR}"/*.desktop
+
+
+  # in case there is only one section
+  # check for existence of key in [Desktop Entry]
+  local seen_key="seen__${section}__${1}"
+  if [[ "${section}" == "[Desktop Entry]" && "${!seen_key}" != "1" ]] ; then
+    warn "Key $1 is not in .desktop file exactly once in section $raw_section"
+  fi
+}
+
+# num_keys_fatal Name # This is not a valid test since [Desktop Action ...] sections can also have Name=
+# num_keys_fatal Exec # This is not a valid test since [Desktop Action ...] sections can also have Name=
+# e.g, https://github.com/CDrummond/cantata/blob/master/cantata.desktop.cmake
+num_keys_fatal Icon
+num_keys_fatal Categories
+# num_keys_warn Comment
+
+# Find the relevant appdata.xml file;
+# according to ximion, usr/share/appdata is a legacy path replaced by usr/share/metainfo
+APPDATA=$(ls "${APPDIR}"/usr/share/metainfo/*appdata.xml "${APPDIR}"/usr/share/metainfo/*metainfo.xml 2>/dev/null | head -n 1)
+if [ -z "$APPDATA" ] ; then
+  APPDATA=$(ls "${APPDIR}"/usr/share/appdata/*appdata.xml 2>/dev/null | head -n 1) # legacy path
+fi
+if [ -z "$APPDATA" ] ; then
+  warn 'No appdata file present. Please provide one in the AppImage as per the instructions on https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps'
+else
+  if [ ! -z $(which appstreamcli) ] ; then
+    appstreamcli validate-tree "${APPDIR}"
+  else
+    echo "Skipping AppStream validation since appstreamcli is not on the \$PATH"
+  fi
+fi
+
+
+BLACKLISTED_FILES=$(cat "${HERE}/excludelist" | sed '/^\s*$/d ; /^#.*$/d ; s/\s*#.*$//')
+for FILE in $BLACKLISTED_FILES ; do
+  if [ ! -z $(find "${APPDIR}" -name $FILE) ] ; then
+    warn "Blacklisted file $FILE found"
+  fi
+done
+
+echo "Lint found no fatal issues"
+exit 0

--- a/scripts/appimage.sh
+++ b/scripts/appimage.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# appimage.sh — assemble + package mdv as an AppImage, PATCHELF-FREE.
+#
+# Why patchelf-free: the usual tools (linuxdeploy) stamp every bundled library
+# with a `$ORIGIN` RUNPATH via patchelf. But patchelf — every version tested,
+# 0.15 through 0.18 — corrupts libraries that carry RELR relocations
+# (`.relr.dyn`), which Fedora's toolchain emits by default. A corrupted lib
+# segfaults in its constructor (`_dl_init`) before main() runs, and *which* lib
+# dies is random per build. So we never rewrite a single ELF: copy the dependency
+# closure byte-pristine and resolve it at runtime via a wrapper AppRun that sets
+# LD_LIBRARY_PATH. (See git history / DEVELOPMENT.md for the full diagnosis.)
+#
+# Run from the repo root after `make release`. Needs: appimagetool on PATH, the
+# two excludelists in scripts/, and qmake6 (for the Qt plugin dir).
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+
+VERSION="$(sed -nE 's/^[[:space:]]*VERSION[[:space:]]+([0-9.]+).*/\1/p' CMakeLists.txt | head -1)"
+[ -n "$VERSION" ] || { echo "appimage.sh: could not parse VERSION from CMakeLists.txt (need a 'VERSION x.y.z' line)" >&2; exit 1; }
+ARCH="$(uname -m)"
+RELEASE_DIR="${RELEASE_DIR:-build-release}"
+DIST_DIR="${DIST_DIR:-dist}"
+APPDIR="$RELEASE_DIR/AppDir"
+QT_PLUGINS="$(qmake6 -query QT_INSTALL_PLUGINS)"
+
+echo "==> AppImage: mdv $VERSION ($ARCH) — patchelf-free"
+rm -rf "$APPDIR"; mkdir -p "$APPDIR/usr/lib" "$APPDIR/usr/plugins" "$DIST_DIR"
+
+# 1. Install mdv via the same install() rules as `make install` (binary,
+#    .desktop, AppStream metainfo, icon).
+cmake --install "$RELEASE_DIR" --prefix "$APPDIR/usr" >/dev/null
+
+# 2. Bundle the Qt plugins a GUI viewer needs (platform, image, icons, style).
+for cat in platforms imageformats iconengines styles platformthemes generic; do
+  [ -d "$QT_PLUGINS/$cat" ] && cp -rL "$QT_PLUGINS/$cat" "$APPDIR/usr/plugins/"
+done
+
+# 3. Copy the shared-library closure PRISTINE (recursive ldd), minus the
+#    host-provided excludelist (upstream AppImage list + scripts/excludelist.mdv).
+EXCL="$(cat scripts/excludelist scripts/excludelist.mdv \
+  | grep -vE '^[[:space:]]*#|^[[:space:]]*$' | sed 's/[[:space:]]*#.*//;s/[[:space:]]//g' | sort -u)"
+collect() {
+  ldd "$1" 2>/dev/null | awk '/=> \// {print $3}' | while read -r so; do
+    b="$(basename "$so")"
+    printf '%s\n' "$EXCL" | grep -qxF "$b" && continue
+    [ -e "$APPDIR/usr/lib/$b" ] && continue
+    cp -L "$so" "$APPDIR/usr/lib/$b" && echo "$APPDIR/usr/lib/$b"
+  done
+}
+queue="$APPDIR/usr/bin/mdv $(find "$APPDIR/usr/plugins" -name '*.so')"
+while [ -n "$queue" ]; do
+  next=""
+  for f in $queue; do next="$next $(collect "$f")"; done
+  queue="$next"
+done
+echo "    bundled $(ls "$APPDIR/usr/lib" | wc -l) libs (pristine)"
+
+# 4. Wrapper AppRun: resolves the pristine libs via LD_LIBRARY_PATH — no per-lib
+#    RUNPATH, so no ELF was rewritten and nothing is corrupted.
+cat > "$APPDIR/AppRun" <<'EOF'
+#!/bin/sh
+HERE="$(dirname "$(readlink -f "$0")")"
+export LD_LIBRARY_PATH="$HERE/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export QT_PLUGIN_PATH="$HERE/usr/plugins"
+export QT_QPA_PLATFORM_PLUGIN_PATH="$HERE/usr/plugins/platforms"
+exec "$HERE/usr/bin/mdv" "$@"
+EOF
+chmod +x "$APPDIR/AppRun"
+
+# 5. Top-level icon, .DirIcon, and .desktop — appimagetool wants them at the root.
+cp "$APPDIR/usr/share/icons/hicolor/512x512/apps/dev.gesslar.mdv.png" "$APPDIR/dev.gesslar.mdv.png"
+ln -sf dev.gesslar.mdv.png "$APPDIR/.DirIcon"
+cp "$APPDIR/usr/share/applications/dev.gesslar.mdv.desktop" "$APPDIR/"
+
+# 6. Validate the AppDir against AppImage's own lint (advisory).
+[ -x scripts/appdir-lint.sh ] && scripts/appdir-lint.sh "$APPDIR" || true
+
+# 7. Package.
+OUT="$DIST_DIR/mdv-$VERSION-$ARCH.AppImage"
+rm -f "$OUT"
+ARCH="$ARCH" appimagetool "$APPDIR" "$OUT"
+echo "==> $OUT"

--- a/scripts/excludelist
+++ b/scripts/excludelist
@@ -1,0 +1,246 @@
+# This file lists libraries that we will assume to be present on the host system and hence
+# should NOT be bundled inside AppImages. This is a working document; expect it to change
+# over time. File format: one filename per line. Each entry should have a justification comment.
+
+# See the useful tool at https://abi-laboratory.pro/index.php?view=navigator&symbol=hb_buffer_set_cluster_level#result
+# to investigate issues with missing symbols.
+
+ld-linux.so.2
+ld-linux-x86-64.so.2
+libanl.so.1
+libBrokenLocale.so.1
+libcidn.so.1
+# libcrypt.so.1 # Not part of glibc anymore as of Fedora 30. See https://github.com/slic3r/Slic3r/issues/4798 and https://pagure.io/fedora-docs/release-notes/c/01d74b33564faa42959c035e1eee286940e9170e?branch=f28
+libc.so.6
+libdl.so.2
+libm.so.6
+libmvec.so.1
+# libnsl.so.1 # Not part of glibc anymore as of Fedora 28. See https://github.com/RPCS3/rpcs3/issues/5224#issuecomment-434930594
+libnss_compat.so.2
+# libnss_db.so.2 # Not part of neon-useredition-20190321-0530-amd64.iso
+libnss_dns.so.2
+libnss_files.so.2
+libnss_hesiod.so.2
+libnss_nisplus.so.2
+libnss_nis.so.2
+libpthread.so.0
+libresolv.so.2
+librt.so.1
+libthread_db.so.1
+libutil.so.1
+# These files are all part of the GNU C Library which should never be bundled.
+# List was generated from a fresh build of glibc 2.25.
+
+libstdc++.so.6
+# Workaround for:
+# usr/lib/libstdc++.so.6: version `GLIBCXX_3.4.21' not found
+
+libGL.so.1
+# The above may be missing on Chrome OS, https://www.reddit.com/r/Crostini/comments/d1lp67/ultimaker_cura_no_longer_running_as_an_appimage/
+libEGL.so.1
+# Part of the video driver (OpenGL); present on any regular
+# desktop system, may also be provided by proprietary drivers.
+# Known to cause issues if it's bundled.
+
+libGLdispatch.so.0
+libGLX.so.0
+# reported to be superfluent and conflicting system libraries (graphics driver)
+# see https://github.com/linuxdeploy/linuxdeploy/issues/89
+
+libOpenGL.so.0
+# Qt installed via install-qt.sh apparently links to this library
+# part of OpenGL like libGL/libEGL, so excluding it should not cause any problems
+# https://github.com/linuxdeploy/linuxdeploy/issues/152
+
+libdrm.so.2
+# Workaround for:
+# Antergos Linux release 2015.11 (ISO-Rolling)
+# /usr/lib/libdrm_amdgpu.so.1: error: symbol lookup error: undefined symbol: drmGetNodeTypeFromFd (fatal)
+# libGL error: unable to load driver: swrast_dri.so
+# libGL error: failed to load driver: swrast
+# Unrecognized OpenGL version
+
+libglapi.so.0
+# Part of mesa
+# known to cause problems with graphics, see https://github.com/RPCS3/rpcs3/issues/4427#issuecomment-381674910
+
+libgbm.so.1
+# Part of mesa
+# https://github.com/probonopd/linuxdeployqt/issues/390#issuecomment-529036305
+
+libxcb.so.1
+# Workaround for:
+# Fedora 23
+# symbol lookup error: /lib64/libxcb-dri3.so.0: undefined symbol: xcb_send_fd
+# Uncertain if this is required to be bundled for some distributions - if so we need to write a version check script and use LD_PRELOAD to load the system version if it is newer
+# Fedora 25:
+# undefined symbol: xcb_send_request_with_fds
+# https://github.com/AppImage/AppImages/issues/128
+
+libX11.so.6
+# Workaround for:
+# Fedora 23
+# symbol lookup error: ./lib/libX11.so.6: undefined symbol: xcb_wait_for_reply64
+# Uncertain if this is required to be bundled for some distributions - if so we need to write a version check script and use LD_PRELOAD to load the system version if it is newer
+
+libX11-xcb.so.1
+# https://github.com/probonopd/linuxdeployqt/issues/582
+# Uncertain if this is required to be bundled for some distributions - if so, please let us know
+
+libwayland-client.so.0
+# https://github.com/AppImageCommunity/pkg2appimage/pull/559
+# https://gitlab.freedesktop.org/mesa/mesa/-/issues/11316
+# New version of Mesa has some dependency issues with libwayland-client if it is bundled
+
+# --- Bundling GLib and its consequences ---
+# The following libraries need to be privately bundled, otherwise this error can happen:
+# - <AppDir>/usr/lib/x86_64-linux-gnu/libgnutls.so.30: version `GNUTLS_3_6_9' not found (required by /lib64/libglib-2.0.so.0)
+# See https://github.com/probonopd/Emacs.AppImage/issues/16
+# - /lib/x86_64-linux-gnu/libgio-2.0.so.0: undefined symbol: g_module_open_full
+# See https://github.com/AppImage/pkg2appimage/pull/500#issuecomment-997183221
+# libgio-2.0.so.0
+# libglib-2.0.so.0
+# libgmodule-2.0.so.0
+# libgobject-2.0.so.0
+# libgthread-2.0.so.0
+# NOTE: Privately bundling libglib-2.0.so.0 and libgobject-2.0.so.0 may break https://wiki.gnome.org/Projects/Libsecret,
+# see https://github.com/probonopd/linuxdeployqt/issues/544 for details
+# NOTE: Privately bundling libgio-2.0.so.0 can lead to this error on Ubuntu:
+# symbol lookup error: /usr/lib/x86_64-linux-gnu/gtk-2.0/modules/liboverlay-scrollbar.so: undefined symbol: g_settings_new
+
+# Since we bundle GLib (again), we have to bundle libpango to avoid undefined symbol: g_memdup2 etc.
+# see, e.g., https://github.com/TheAssassin/AppImageLauncher/issues/508
+# libpangoft2-1.0.so.0
+# libpangocairo-1.0.so.0
+# libpango-1.0.so.0
+# NOTE: Pango requires libharfbuzz >= 2.6.0 which isn't available on some older systems, so this error can happen:
+# libpango-1.0.so.0: undefined symbol: hb_ot_layout_get_horizontal_baseline_tag_for_script
+# See https://github.com/AppImageCommunity/pkg2appimage/issues/528
+
+# Commented as we currently bundle libpango
+# If libthai is bundled but libpango is not, this error can happen:
+# audacity: /tmp/.mount_AudaciUsFbON/usr/lib/libthai.so.0: version `LIBTHAI_0.1.25' not found (required by /usr/lib64/libpango-1.0.so.0)
+# on openSUSE Tumbleweed
+# libthai.so.0
+# If libcairo is bundled but libpango is not, this error can happen:
+# Can get symbol lookup error: /lib64/libpango-1.0.so.0: undefined symbol: g_log_structured_standard
+# --- Bundling GLib and its consequences ---
+
+# libgdk-x11-2.0.so.0 # Missing on openSUSE-Tumbleweed-KDE-Live-x86_64-Snapshot20170601-Media.iso
+# libgtk-x11-2.0.so.0 # Missing on openSUSE-Tumbleweed-KDE-Live-x86_64-Snapshot20170601-Media.iso
+
+libasound.so.2
+# Workaround for:
+# No sound, e.g., in VLC.AppImage (does not find sound cards)
+
+# https://github.com/AppImage/pkg2appimage/issues/475
+# libgdk_pixbuf-2.0.so.0
+# Was: Workaround for:
+# On Ubuntu, get (inkscape:25621): GdkPixbuf-WARNING **: Error loading XPM image loader: Image type 'xpm' is not supported
+
+libfontconfig.so.1
+# Workaround for:
+# Application stalls when loading fonts during application launch; e.g., KiCad on ubuntu-mate
+
+# other "low-level" font rendering libraries
+# should fix https://github.com/probonopd/linuxdeployqt/issues/261#issuecomment-377522251
+# and https://github.com/probonopd/linuxdeployqt/issues/157#issuecomment-320755694
+libfreetype.so.6
+libharfbuzz.so.0
+
+# Note, after discussion we do not exclude this, but we can use a dummy library that just does nothing
+# libselinux.so.1
+# Workaround for:
+# sed: error while loading shared libraries: libpcre.so.3: cannot open shared object file: No such file or directory
+# Some distributions, such as Arch Linux, do not come with libselinux.so.1 by default.
+# The solution is to bundle a dummy mock library:
+# echo "extern int is_selinux_enabled(void){return 0;}" >> selinux-mock.c
+# gcc -s -shared -o libselinux.so.1 -Wl,-soname,libselinux.so.1 selinux-mock.c
+# strip libselinux.so.1
+# More information: https://github.com/AppImage/AppImages/issues/83
+# and https://github.com/AppImage/AppImageKit/issues/775#issuecomment-614954821
+# https://gitlab.com/sulinos/devel/libselinux-dummy
+
+# The following are assumed to be part of the base system
+# Removing these has worked e.g., for Krita. Feel free to report if
+# you think that some of these should go into AppImages and why.
+libcom_err.so.2
+libexpat.so.1
+libgcc_s.so.1
+libgpg-error.so.0
+# libgssapi_krb5.so.2 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
+# libgssapi.so.3 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+# libhcrypto.so.4 # Missing on openSUSE LEAP 42.0
+# libheimbase.so.1 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+# libheimntlm.so.0 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+# libhx509.so.5 # Missing on openSUSE LEAP 42.0
+libICE.so.6
+# libidn.so.11 # Does not come with Solus by default
+# libk5crypto.so.3 # Running AppImage built on Debian 9 or Ubuntu 16.04 on an Archlinux fails otherwise; https://github.com/AppImage/AppImages/issues/301
+# libkeyutils.so.1 # Does not come with Void Linux by default; https://github.com/Subsurface-divelog/subsurface/issues/1971#issuecomment-466606834
+# libkrb5.so.26 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there. Missing on openSUSE LEAP 42.0
+# libkrb5.so.3 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
+# libkrb5support.so.0 # Disputed, seemingly needed by Arch Linux since Kerberos is named differently there
+# libp11-kit.so.0 # https://github.com/AppImageCommunity/pkg2appimage/issues/547
+# libpcre.so.3 # Missing on Fedora 24, SLED 12 SP1, and openSUSE Leap 42.2
+# libroken.so.18 # Mission on openSUSE LEAP 42.0
+# libsasl2.so.2 # Seemingly needed when running Ubuntu 14.04 binaries on Fedora 23
+libSM.so.6
+libusb-1.0.so.0
+libuuid.so.1
+# libwind.so.0 # Missing on openSUSE LEAP 42.0
+libz.so.1
+
+# Workaround for:
+# e.g., Spotify
+# relocation error: /lib/x86_64-linux-gnu/libgcrypt.so.20:
+# symbol gpgrt_lock_lock, version GPG_ERROR_1.0 not defined
+# in file libgpg-error.so.0 with link time reference
+libgpg-error.so.0
+
+libjack.so.0
+# it must match the ABI of the JACK server which is installed in the base system
+# rncbc confirmed this
+# However, this library is missing on Fedora-WS-Live-31-1-9
+# which means that we should avoid using JACK altogether if possible
+
+libpipewire-0.3.so.0
+# like libjack, it must match the ABI of the JACK server which is installed in the base system
+# https://github.com/linuxdeploy/linuxdeploy/issues/292
+
+# Unsolved issue:
+# https://github.com/probonopd/linuxdeployqt/issues/35
+# Error initializing NSS with a persistent database (sql:/home/me/.pki/nssdb): libsoftokn3.so: cannot open shared object file: No such file or directory
+# Error initializing NSS without a persistent database: NSS error code: -5925
+# nss_error=-5925, os_error=0
+# libnss3.so should not be removed from the bundles, as this causes other issues, e.g.,
+# https://github.com/probonopd/linuxdeployqt/issues/35#issuecomment-256213517
+# and https://github.com/AppImage/AppImages/pull/114
+# libnss3.so
+
+# The following cannot be excluded, see
+# https://github.com/AppImage/AppImages/commit/6c7473d8cdaaa2572248dcc53d7f617a577ade6b
+# http://stackoverflow.com/questions/32644157/forcing-a-binary-to-use-a-specific-newer-version-of-a-shared-library-so
+# libssl.so.1
+# libssl.so.1.0.0
+# libcrypto.so.1
+# libcrypto.so.1.0.0
+
+# According to https://github.com/RicardoEPRodrigues/3Engine/issues/4#issuecomment-511598362
+# libGLEW is not tied to a specific GPU. It's linked against libGL.so.1
+# and that one is different depending on the installed driver.
+# In fact libGLEW is changing its soversion very often, so you should always bundle libGLEW.so.2.0
+
+# libglut.so.3 # to be confirmed
+
+libxcb-dri3.so.0 # https://github.com/AppImage/AppImages/issues/348
+libxcb-dri2.so.0 # https://github.com/probonopd/linuxdeployqt/issues/331#issuecomment-442276277
+
+# If the next line turns out to cause issues, we will have to remove it again and find another solution
+libfribidi.so.0 # https://github.com/olive-editor/olive/issues/221 and https://github.com/knapsu/plex-media-player-appimage/issues/14
+
+# Workaround for:
+# symbol lookup error: /lib/x86_64-linux-gnu/libgnutls.so.30: undefined symbol: __gmpz_limbs_write
+# https://github.com/ONLYOFFICE/appimage-desktopeditors/issues/3
+# Apparently coreutils depends on it, so it should be safe to assume that it comes with every target system
+libgmp.so.10

--- a/scripts/excludelist.mdv
+++ b/scripts/excludelist.mdv
@@ -1,0 +1,53 @@
+# mdv (Qt 6 / KF6) excludelist additions — layered ON TOP of the upstream
+# AppImage excludelist (scripts/excludelist, kept byte-identical to upstream) by
+# `make appimage`. NONE of these are on the upstream list; keeping them separate
+# means the canonical file stays pristine and diffable against upstream.
+#
+# Why a lib is here (one of two reasons):
+#   1. Host-coupled system lib whose *bundled* copy crashes mdv at load — a
+#      constructor segfault in _dl_init. Core-dump confirmed for libudev and
+#      libcbor; the rest are the same systemd / security subtree.
+#   2. Network / auth / crypto lib that linuxdeploy-plugin-qt over-bundles via
+#      Qt's optional plugins — a local-file markdown viewer never uses any of it.
+# Every Linux desktop ships these with a stable ABI, so the host copy is the
+# right one; excluding them means "load from the host," which is the AppImage way.
+
+# systemd / udev / dbus
+libudev.so.1
+libsystemd.so.0
+libdbus-1.so.3
+
+# TLS / crypto / FIDO (systemd-subtree orphans; unused by mdv)
+libssl.so.3
+libcrypto.so.3
+libcbor.so.0
+libfido2.so.1
+libcrypt.so.2
+
+# network transfer stack (mdv opens local files — no network)
+libcurl.so.4
+libssh.so.4
+libproxy.so.1
+libpxbackend-1.0.so
+libduktape.so.207
+libnghttp2.so.14
+libnghttp3.so.9
+libngtcp2.so.16
+libngtcp2_crypto_ossl.so.0
+libpsl.so.5
+libidn2.so.0
+
+# kerberos / ldap / sasl auth
+libgssapi_krb5.so.2
+libkrb5.so.3
+libkrb5support.so.0
+libk5crypto.so.3
+libldap.so.2
+liblber.so.2
+libsasl2.so.3
+libkeyutils.so.1
+
+# misc host system
+libselinux.so.1
+libblkid.so.1
+libmount.so.1


### PR DESCRIPTION
Add AppImage packaging target (patchelf-free, RELR-safe)

## Motivation

The standard AppImage toolchain (`linuxdeploy`) rewrites bundled libraries with `$ORIGIN` RUNPATHs via `patchelf`. Every version of patchelf tested (0.15–0.18) corrupts libraries carrying RELR relocations (`.relr.dyn`), which Fedora's toolchain emits by default. The result is a random library segfaulting in `_dl_init` before `main()` runs. Since we cannot safely rewrite any ELF, the entire deploy is hand-rolled.

## Approach

`scripts/appimage.sh` assembles the AppDir without touching a single ELF:

1. Installs `mdv` via CMake's own `install()` rules
2. Copies required Qt plugins
3. Walks the full shared-library closure with `ldd`, copying each library byte-pristine while filtering against the exclude lists
4. Writes a wrapper `AppRun` that sets `LD_LIBRARY_PATH` and `QT_PLUGIN_PATH` at runtime — no RUNPATH stamping needed

## Exclude lists

- `scripts/excludelist` — the upstream AppImage project list, kept byte-identical and diffable against upstream
- `scripts/excludelist.mdv` — our additions: systemd/udev/dbus, TLS/crypto/FIDO, the full network transfer stack (curl, ssh, nghttp2, etc.), Kerberos/LDAP/SASL, and other host-coupled libs. A local markdown viewer never uses any of this; the host copy is always the right one

## Validation

`scripts/appdir-lint.sh` (taken straight from the AppImage project) validates the assembled AppDir against AppImageHub's rules before packaging.

## Usage

```bash
make appimage   # → dist/mdv-<version>-<arch>.AppImage
```

Requires `appimagetool` on `PATH` (packaging dep only, not a build dep). The AppImage is intentionally excluded from the `dist` target since it is its own distribution format.

> **Note:** The AppImage is currently built on the host, so its glibc floor matches the build host. A reproducible Fedora container build is a planned follow-up.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a patchelf-free AppImage packaging target (`make appimage`) that hand-rolls the dependency deploy — copying the full shared-library closure byte-pristine and resolving it at runtime via a wrapper `AppRun` that sets `LD_LIBRARY_PATH` — because every tested patchelf version corrupts RELR-relocated libraries emitted by Fedora's toolchain.

- `scripts/appimage.sh` assembles the AppDir via CMake's own install rules, copies Qt plugins, walks the shared-library closure with an iterative `ldd`-based BFS, writes the `AppRun` wrapper, and packages with `appimagetool`. The implementation is clean: `qmake6` is used directly (no Qt5 fallback), the exclude-list matching is correct, and all paths are `set -e` safe.
- `scripts/excludelist.mdv` adds project-specific exclusions (systemd, TLS, network stack, Kerberos) on top of the upstream exclude list, kept separate so the canonical file remains diffable against upstream.
- `scripts/appdir-lint.sh` is taken verbatim from the AppImage project and invoked advisorially (`|| true`); it has pre-existing dead-`$?`-under-`set -e` issues flagged in earlier review threads.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it adds a new optional packaging target that does not affect any existing build paths.

All three previously flagged issues appear addressed: libcbor.so.0.13 is now in soname form, qmake6 has no Qt5 fallback, and the lint script issues are upstream-inherited and invoked advisorially. The one new finding is a diagnostic gap rather than a defect in any currently-exercised code path.

No files require special attention; the new packaging scripts are self-contained and do not touch any build or runtime logic for the existing targets.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Fappimage.sh%3A46-51%0A**Silent%20drop%20of%20%60ldd%60%20%22not%20found%22%20dependencies**%0A%0A%60awk%20'%2F%3D%3E%20%5C%2F%2F%20%7Bprint%20%243%7D'%60%20naturally%20excludes%20%60libfoo.so.1%20%3D%3E%20not%20found%60%20lines.%20If%20the%20build%20host%20is%20missing%20any%20required%20library%20%28possible%20in%20container%20or%20CI%20environments%20%E2%80%94%20which%20the%20PR%20description%20calls%20out%20as%20a%20planned%20follow-up%29%2C%20those%20libraries%20are%20silently%20omitted%20from%20the%20bundle%20with%20no%20build-time%20error.%20The%20AppImage%20then%20fails%20at%20runtime%20with%20a%20missing-symbol%20error%20that%20is%20difficult%20to%20attribute%20to%20the%20packaging%20step.%20Adding%20a%20separate%20%60ldd%20...%20%7C%20grep%20'%3D%3E%20not%20found'%60%20pass%20that%20prints%20a%20warning%20%28even%20without%20failing%29%20before%20the%20awk%20collection%20would%20surface%20incomplete%20bundles%20immediately.%0A%0A&repo=gesslar%2Fmdv.qt&pr=14&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["feat: AppImage packaging (patchelf-free)..."](https://github.com/gesslar/mdv.qt/commit/bf5873394c2193d82ec45466760559014b4f651f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33851535)</sub>

<!-- /greptile_comment -->