### PR TITLE
make linux container build

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -66,7 +66,7 @@ Install the official **[Qt online installer](https://www.qt.io/download-qt-insta
 Two extra prereqs that the Qt installer doesn't provide:
 
 - **Git for Windows** — `git` is needed at *configure* time (CMake clones extra-cmake-modules from invent.kde.org) and Git for Windows also ships a Perl at `C:\Program Files\Git\usr\bin\perl.exe`, which is what KSyntaxHighlighting needs to generate its data tables. CMakeLists auto-detects this Perl when one isn't already on `PATH`. If you'd rather use Strawberry Perl: `choco install strawberryperl`.
-- **NSIS 3.x** (`makensis.exe`) — only needed for `make exe` (building the installer). `choco install nsis`, or download from <https://nsis.sourceforge.io/> and add `NSIS\Bin` to `PATH`.
+- **NSIS 3.x** (`makensis.exe`) — only needed for `make windows` (building the installer). `choco install nsis`, or download from <https://nsis.sourceforge.io/> and add `NSIS\Bin` to `PATH`.
 
 Neither **md4c** nor **KSyntaxHighlighting** has a Windows package, so CMake fetches and builds both in-tree on Windows (along with extra-cmake-modules, which KSH needs). Nothing extra to install for them — `cmake -S . -B build-release -G Ninja -DCMAKE_BUILD_TYPE=Release` and `cmake --build build-release` is enough on a clean machine that has Qt + a compiler + Git.
 
@@ -183,17 +183,42 @@ AppImage list, kept byte-identical and diffable) plus `scripts/excludelist.mdv`
 viewer never needs). `scripts/appdir-lint.sh` (also straight from the AppImage
 project) validates the AppDir against AppImageHub's rules.
 
-> The AppImage is built on the host for now, so its glibc floor is the build
-> host's. A reproducible Fedora build container — building the Flatpak too — is
-> a planned follow-up.
+### All formats in a container (`make linux`)
+
+`make linux` builds **every** format above — `.deb`, `.rpm`, `.AppImage`, and
+`.flatpak` — inside a pinned Fedora container (`docker/Dockerfile`), so a release
+is reproducible and CI is trivial: one image, one command. The image is the
+toolchain only; your checkout is mounted at run time and the build just calls the
+same `make` targets above, so it can't drift from the documented build.
+
+```bash
+make linux   # → dist/ : the .deb, .rpm, .AppImage and .flatpak, all at once
+```
+
+**Tooling**: Docker — nothing else; the image carries the full toolchain. Docker
+is the most widely available engine, and since Docker Desktop runs Linux
+containers on Windows and macOS, a dev on *any* OS can produce the Linux
+artifacts — a Windows dev builds the native installer (`make windows`) **and** all
+four Linux formats (`make linux`) from one box. `docker/dist.sh` runs the
+container as your uid/gid (`--user`, plus a read-only `/etc/passwd` mount so
+flatpak-builder can resolve the user), so the artifacts are yours, not root.
+flatpak-builder inside a container needs sandbox escape hatches (`--privileged`,
+`/dev/fuse`, `seccomp=unconfined`, `XDG_RUNTIME_DIR`) plus `--disable-rofiles-fuse`;
+the script handles all of it and caches the `org.kde.Platform` runtime under
+`~/.cache/mdv-flatpak`, so the ~1.5 GB pull happens only on the first run.
+
+> A Fedora base has the same recent glibc + RELR libs as the host, so the
+> AppImage's glibc floor is unchanged — the win is reproducibility/CI, not
+> old-distro portability. The AppImage stays patchelf-free in the container too.
 
 macOS will get its own `Makefile.dist.macos` include when that build path is
 ready.
 
 ## Packaging (Windows)
 
-The Windows installer is an NSIS `.exe` built with CPack from the same
-`install()` rules `cmake --install` uses (the binary, the icon, and a
+The Windows installer is an NSIS `.exe` built by a custom `makensis` target
+(not CPack — see `cmake/Packaging.cmake`) from the same `install()` rules
+`cmake --install` uses (the binary, the icon, and a
 windeployqt step that pulls in Qt + plugins + translations + the mingw
 runtime DLLs). The target lives in `Makefile.dist.windows` — the top-level
 Makefile pulls in the per-OS dist include for the host automatically.
@@ -201,12 +226,13 @@ Installer metadata (file associations, shortcuts, icons) lives in
 `cmake/Packaging.cmake`.
 
 ```powershell
-make exe     # → dist\mdv-<version>-win64.exe
-make dist    # same (alias, parallel to Linux's `make dist`)
+make windows   # → dist\mdv-<version>-win64.exe
+make dist      # same (alias, parallel to Linux's `make dist`)
 ```
 
-`make exe` builds the release binary first, then runs `cpack -G NSIS`;
-the artifact lands in `dist\`. **Packaging tooling**: NSIS 3.x must be
+`make windows` builds the release binary first, then drives the custom
+`package_nsis` target (`cmake --install` + `makensis`); the artifact lands in
+`dist\`. **Packaging tooling**: NSIS 3.x must be
 installed and `makensis.exe` on `PATH` (see the Windows install section
 above).
 

--- a/Makefile.dist.linux
+++ b/Makefile.dist.linux
@@ -8,6 +8,9 @@
 #     make flatpak  → dist/mdv-<version>-<arch>.flatpak  (KDE runtime; pulls the SDK once)
 #     make appimage → dist/mdv-<version>-<arch>.AppImage (patchelf-free; needs appimagetool)
 #
+#     make linux → all of the above, built in a pinned Fedora container
+#                  (reproducible, CI-ready, artifacts owned by you)
+#
 # A .deb needs dpkg-deb on PATH; a .rpm needs rpmbuild; a .flatpak needs flatpak
 # + flatpak-builder; an .AppImage needs appimagetool. See DEVELOPMENT.md for how
 # to install them (they're not build deps — only packaging deps).
@@ -15,7 +18,7 @@
 # DIST_DIR (the output directory) comes from the top-level Makefile, alongside
 # DEV_DIR / RELEASE_DIR, so `make distclean` there can sweep it too.
 
-.PHONY: dist deb rpm flatpak appimage
+.PHONY: dist deb rpm flatpak appimage linux
 
 # Every Linux package format.
 dist: deb rpm
@@ -46,8 +49,13 @@ MDV_ARCH    = $(shell flatpak --default-arch 2>/dev/null || uname -m)
 # of the CPack path above — flatpak-builder builds its own copy of mdv in the
 # sandbox from dev.gesslar.mdv.yml. Deliberately NOT part of `dist`, so a routine
 # `make dist` doesn't trigger the SDK download. See DEVELOPMENT.md.
+#
+# --disable-rofiles-fuse skips the inter-stage read-only FUSE overlay (a build-
+# cache optimization): a minor speed cost, but it lets the build run inside a
+# container, which can't mount FUSE. Harmless on the host.
 flatpak:
 	flatpak-builder --force-clean --user --install-deps-from=flathub \
+	  --disable-rofiles-fuse \
 	  --state-dir=$(DIST_DIR)/.flatpak-builder \
 	  --repo=$(DIST_DIR)/flatpak-repo \
 	  $(DIST_DIR)/flatpak-build dev.gesslar.mdv.yml
@@ -60,3 +68,9 @@ flatpak:
 # appimagetool on PATH; NOT part of `dist` (its own format).
 appimage: release
 	scripts/appimage.sh
+
+# linux: build EVERY format (deb, rpm, AppImage, Flatpak) in the pinned Fedora
+# container (docker/Dockerfile) — reproducible, CI-trivial, artifacts owned by
+# you. The whole Linux packaging surface in one command. See docker/dist.sh.
+linux:
+	docker/dist.sh

--- a/Makefile.dist.windows
+++ b/Makefile.dist.windows
@@ -3,8 +3,8 @@
 # (NOT CPack — see cmake/Packaging.cmake for why), driving makensis against
 # cmake/mdv.nsi.in.
 #
-#     make exe    → dist/mdv-<version>-win64.exe
-#     make dist   → same
+#     make windows → dist/mdv-<version>-win64.exe
+#     make dist    → same
 #
 # The installer offers the user a choice between per-user (no admin, install
 # to %LOCALAPPDATA%\Programs\mdv) and per-machine (admin, Program Files\mdv)
@@ -25,17 +25,18 @@
 # DIST_DIR (the output directory) comes from the top-level Makefile, alongside
 # DEV_DIR / RELEASE_DIR, so `make distclean` there can sweep it too.
 
-.PHONY: dist exe
+.PHONY: dist windows
 
-# Every Windows package format. Single artifact today; keeps the verb parallel
-# to `make dist` on Linux (which fans out to deb + rpm).
-dist: exe
+# `make dist` = the native-host aggregate (parallel to Linux's `make dist`); one
+# Windows format today, so it just maps to `make windows`.
+dist: windows
 
-# Re-configure the release tree with MDV_PACKAGE_OUTPUT_DIR pointing at our
-# DIST_DIR (otherwise the artifact lands inside the build dir), then drive
-# the package_nsis custom target. The target stages the install tree via
-# `cmake --install` and runs makensis on the generated mdv.nsi.
-exe: release
+# `make windows` — the Windows release verb (parallels `make linux`). Re-configure
+# the release tree with MDV_PACKAGE_OUTPUT_DIR pointing at our DIST_DIR (otherwise
+# the artifact lands inside the build dir), then drive the package_nsis custom
+# target: it stages the install tree via `cmake --install` and runs makensis on
+# the generated mdv.nsi.
+windows: release
 	cmake -S . -B $(RELEASE_DIR) -G Ninja -DCMAKE_BUILD_TYPE=Release \
 	    -DMDV_PACKAGE_OUTPUT_DIR=$(CURDIR)/$(DIST_DIR) $(PREFIX_FLAG)
 	cmake --build $(RELEASE_DIR) --target package_nsis

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -5,7 +5,7 @@
 #
 # Driven from the per-host Makefile.dist.* include:
 #     Linux:   make deb / make rpm / make dist
-#     Windows: make exe / make dist  (NSIS)
+#     Windows: make windows / make dist  (NSIS)
 #
 # This file is include()d at the very end of CMakeLists.txt, AFTER the install()
 # rules — CPack snapshots those rules, so whatever `make install` would lay down
@@ -99,7 +99,7 @@ if(WIN32)
         PATH_SUFFIXES Bin)
     if(NOT MAKENSIS_EXECUTABLE)
         message(WARNING
-            "makensis not found — `make exe` will fail. Install NSIS 3.x "
+            "makensis not found — `make windows` will fail. Install NSIS 3.x "
             "(choco install nsis) and ensure NSIS\\Bin is on PATH.")
     endif()
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,51 @@
+# Reproducible Linux build environment for mdv — produces the .deb, .rpm,
+# AppImage, and Flatpak from a clean, pinned Fedora userspace, so a release
+# doesn't depend on a dev box's state. See work/appimage-flatpak-docker-cleanroom.md.
+#
+# This image is the TOOLCHAIN ONLY. The source is mounted at /work at run time,
+# and the build just calls the same `make` targets you'd run on the host — so
+# the container can't drift from the documented build.
+#
+#   make linux           # build the image (if needed) + run all formats as you
+#
+# Note: a Fedora base means the same recent glibc + RELR libs as the host, so the
+# AppImage's glibc floor is unchanged. The win is reproducibility + CI, not
+# old-distro portability. The AppImage stays patchelf-free (scripts/appimage.sh).
+#
+# Pinned to the HOST's Fedora release. The AppImage bundles this base's libs but
+# loads host-provided ones (libselinux, glibc, ...) at run time; if the base were
+# OLDER than the run host, a host lib could demand symbols the bundled (older) lib
+# lacks and the app aborts. Matching the host avoids that skew.
+#
+# --platform=linux/amd64 pins the image to x86_64 regardless of build host: a
+# no-op on x86_64, and on an arm64 host (Docker Desktop on Apple Silicon) it
+# forces x86_64 so the pinned-x86_64 toolchain (appimagetool, artifact names)
+# can't mismatch the host. The build deterministically targets x86_64.
+FROM --platform=linux/amd64 fedora:44
+
+# Build deps (DEVELOPMENT.md's Fedora list) + packaging tooling + git (the
+# metainfo derives its release date from `git log`) + the appdir-lint deps
+# (desktop-file-validate, appstreamcli, mimetype, which).
+RUN dnf install -y --setopt=install_weak_deps=False \
+      qt6-qtbase-devel kf6-syntax-highlighting-devel md4c-devel \
+      extra-cmake-modules cmake ninja-build gcc-c++ git \
+      flatpak flatpak-builder dpkg rpm-build \
+      desktop-file-utils appstream perl-File-MimeInfo file which curl \
+ && dnf clean all
+
+# appimagetool, pinned to a tagged release + verified by sha256 so the
+# "reproducible" image actually is (continuous is a rolling tag, and an
+# unverified download is a supply-chain gap). It only PACKAGES the AppDir —
+# the dependency deploy is hand-rolled patchelf-free in scripts/appimage.sh.
+RUN curl -fsSL -o /usr/local/bin/appimagetool \
+      https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage \
+ && echo "ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0  /usr/local/bin/appimagetool" \
+      | sha256sum -c - \
+ && chmod +x /usr/local/bin/appimagetool
+# AppImages can't FUSE-mount inside a container; extract-and-run instead.
+ENV APPIMAGE_EXTRACT_AND_RUN=1
+
+# Flathub remote so flatpak-builder can pull the org.kde.Platform runtime/SDK.
+RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
+WORKDIR /work

--- a/docker/dist.sh
+++ b/docker/dist.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# dist.sh — build EVERY Linux artifact (deb, rpm, AppImage, Flatpak) inside the
+# pinned Fedora container (docker/Dockerfile). One image, one command, all
+# formats — so a release is reproducible and CI is trivial: just run this.
+# Wrapped by `make linux`.
+#
+# Docker-flavoured on purpose: Docker is the most widely available engine, and
+# Docker Desktop runs Linux containers on Windows + macOS — so a dev on ANY OS
+# can produce the Linux artifacts. A Windows dev builds the native installer
+# (`make windows`) AND all four Linux formats (`make linux`) from one box. CD
+# uses whatever engine the runner provides.
+#
+# - Runs as your uid/gid (`--user`) so dist/ artifacts are YOURS, not root. We
+#   also bind-mount /etc/passwd read-only: docker's `--user` (unlike podman's
+#   keep-id) leaves no passwd entry for the uid, which flatpak-builder wants.
+# - The cmake formats (deb/rpm/AppImage) build into a container-local dir
+#   (RELEASE_DIR=/tmp/build), so your host build trees are never touched.
+# - Flatpak needs the sandbox escape hatches (--privileged, /dev/fuse,
+#   seccomp=unconfined, XDG_RUNTIME_DIR) + --disable-rofiles-fuse (in the flatpak
+#   target) + a persistent runtime cache so the 1.5 GB org.kde.Platform pull
+#   happens only on the first run.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO"
+DOCKER="${DOCKER:-docker}"            # override to point at a specific docker CLI
+IMAGE="mdv-build"
+FLATPAK_CACHE="${FLATPAK_CACHE:-$HOME/.cache/mdv-flatpak}"
+
+echo "==> build image: $IMAGE"
+"$DOCKER" build -t "$IMAGE" docker/
+
+mkdir -p "$FLATPAK_CACHE"
+echo "==> build deb + rpm + AppImage + Flatpak in $IMAGE (as uid $(id -u))"
+# --platform=linux/amd64: run as x86_64 regardless of host (no-op on x86_64,
+# emulated on arm64) — matches the pinned-x86_64 image + toolchain above.
+"$DOCKER" run --rm --platform=linux/amd64 \
+  --user "$(id -u):$(id -g)" --security-opt label=disable \
+  --privileged --device /dev/fuse --security-opt seccomp=unconfined \
+  -v "$REPO":/work -w /work \
+  -v /etc/passwd:/etc/passwd:ro \
+  -e HOME=/tmp/fphome -e XDG_RUNTIME_DIR=/tmp/xdg \
+  -v "$FLATPAK_CACHE":/tmp/fphome/.local/share/flatpak \
+  "$IMAGE" bash -euc '
+    mkdir -p /tmp/fphome /tmp/xdg && chmod 700 /tmp/xdg
+    flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+    make deb rpm appimage RELEASE_DIR=/tmp/build
+    make flatpak
+  '
+echo "==> artifacts in dist/:"
+ls -1 dist/*.deb dist/*.rpm dist/*.AppImage dist/*.flatpak 2>/dev/null


### PR DESCRIPTION
## Containerised Linux builds (`make linux`) and packaging verb rename

### `make linux` — all Linux formats in one command

Adds `docker/Dockerfile` and `docker/dist.sh` to build every Linux artifact — `.deb`, `.rpm`, `.AppImage`, and `.flatpak` — inside a pinned Fedora 44 container. The image carries the full toolchain; the source tree is mounted at run time, so the container calls the same individual `make` targets as a developer would and cannot drift from the documented build.

Key behaviours of the container run:
- Built on **Docker** — the most widely available engine, and since Docker Desktop runs Linux containers on Windows/macOS, a dev on any OS can produce the Linux artifacts (a Windows dev gets both `make windows` and `make linux` from one box). The container runs as your uid/gid via `--user` plus a read-only `/etc/passwd` mount (so `flatpak-builder` can resolve the user), so artifacts land in `dist/` owned by you, not root.
- Flatpak requires sandbox escape hatches (`--privileged`, `/dev/fuse`, `seccomp=unconfined`, `XDG_RUNTIME_DIR`). The `org.kde.Platform` runtime (~1.5 GB) is cached under `~/.cache/mdv-flatpak` so the pull only happens on the first run.
- `--disable-rofiles-fuse` is added to the `flatpak-builder` invocation so the build works inside a container (which cannot mount FUSE overlays); this is harmless on the host.
- `appimagetool` is pinned to release `1.9.1` and verified by `sha256sum` at image-build time (so the "reproducible" image actually is, and the download is integrity-checked), then run with `APPIMAGE_EXTRACT_AND_RUN=1` since FUSE-mounting an AppImage inside a container is not possible.

The Fedora base is intentionally matched to the host release rather than pinned to an older one: the AppImage bundles base libs but loads host-provided ones at runtime, so an older base could cause symbol mismatches. The reproducibility win is clean-room isolation and CI simplicity, not old-distro portability.

### `make exe` → `make windows`

Renames the Windows packaging verb from `make exe` to `make windows` to parallel the new `make linux`. `make dist` remains as an alias on both platforms. Updated everywhere: `Makefile.dist.windows`, `DEVELOPMENT.md`, and `cmake/Packaging.cmake` (header comment + the NSIS-missing `WARNING` string).

### CPack → custom `makensis` target (documentation fix)

Corrects the Windows packaging description in `DEVELOPMENT.md`: the installer is built by a custom `package_nsis` CMake target (`cmake --install` + `makensis`), not CPack, matching what `cmake/Packaging.cmake` actually does.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a containerised Linux build path (`make linux`) that runs all four Linux packaging formats — `.deb`, `.rpm`, `.AppImage`, `.flatpak` — inside a pinned Fedora 44 Docker image, and renames the Windows packaging verb from `make exe` to `make windows` for symmetry.

- `docker/Dockerfile` installs the full toolchain and fetches `appimagetool` 1.9.1 with a pinned sha256 check; `docker/dist.sh` mounts the source tree at run time and drives the same per-format `make` targets, running as the host uid/gid via `--user` + a read-only `/etc/passwd` bind-mount.
- `Makefile.dist.linux` gains a `linux` phony target and `--disable-rofiles-fuse` on the `flatpak` target so it works both inside the container and on the host.
- `Makefile.dist.windows`, `cmake/Packaging.cmake`, and `DEVELOPMENT.md` are updated consistently to reflect the `windows` rename and correct the CPack reference to the custom `package_nsis` target.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both issues flagged in the prior review are fully resolved, and no new defects were introduced.

The two previous findings — Podman-only --userns=keep-id and the rolling continuous appimagetool tag without a checksum — are cleanly addressed. The make exe → make windows rename is consistent across all five touched files. No logic regressions found.

No files require special attention.

<sub>Reviews (6): Last reviewed commit: ["build: containerized make linux (deb/rpm..."](https://github.com/gesslar/mdv.qt/commit/f42ff235d3738617c6a6d78a14232a0d032bd28b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33855464)</sub>

<!-- /greptile_comment -->