### PR TITLE
bump to 2.0.1, fix flatpak bundle branch and runtime repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(mdv
-    VERSION 2.0.0
+    VERSION 2.0.1
     DESCRIPTION "An offline Markdown viewer for everybody! For free! Huzzah!"
     LANGUAGES CXX
 )

--- a/Makefile.dist.linux
+++ b/Makefile.dist.linux
@@ -53,13 +53,22 @@ MDV_ARCH    = $(shell flatpak --default-arch 2>/dev/null || uname -m)
 # --disable-rofiles-fuse skips the inter-stage read-only FUSE overlay (a build-
 # cache optimization): a minor speed cost, but it lets the build run inside a
 # container, which can't mount FUSE. Harmless on the host.
+#
+# --runtime-repo stamps the flathub URL into the bundle. A single-file .flatpak
+# carries ONLY the app, never its runtime — so on install, flatpak needs to know
+# where to fetch org.kde.Platform from. Without this, `flatpak install foo.flatpak`
+# dies with "requires the runtime org.kde.Platform/.../6.9 which was not found"
+# on any machine (or scope) that doesn't already have that exact runtime. With it,
+# flatpak offers to pull the runtime from flathub automatically.
 flatpak:
 	flatpak-builder --force-clean --user --install-deps-from=flathub \
 	  --disable-rofiles-fuse \
 	  --state-dir=$(DIST_DIR)/.flatpak-builder \
 	  --repo=$(DIST_DIR)/flatpak-repo \
 	  $(DIST_DIR)/flatpak-build dev.gesslar.mdv.yml
-	flatpak build-bundle $(DIST_DIR)/flatpak-repo \
+	flatpak build-bundle \
+	  --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo \
+	  $(DIST_DIR)/flatpak-repo \
 	  $(DIST_DIR)/mdv-$(MDV_VERSION)-$(MDV_ARCH).flatpak dev.gesslar.mdv
 
 # AppImage: a patchelf-free single-file bundle. scripts/appimage.sh hand-rolls

--- a/Makefile.dist.linux
+++ b/Makefile.dist.linux
@@ -42,6 +42,11 @@ rpm: release
 # referenced once, so there's no re-eval cost.
 MDV_VERSION = $(shell sed -nE 's/^[[:space:]]*VERSION[[:space:]]+([0-9.]+).*/\1/p' CMakeLists.txt | head -1)
 MDV_ARCH    = $(shell flatpak --default-arch 2>/dev/null || uname -m)
+# The flatpak branch (release channel) flatpak-builder exports the app under.
+# build-bundle defaults its branch arg to "master", so we MUST pass it the real
+# one or it bundles a stale/absent master ref. Sourced from default-branch in the
+# manifest so the manifest stays the single source (mirrors MDV_VERSION above).
+MDV_BRANCH  = $(shell sed -nE 's/^default-branch:[[:space:]]*([^[:space:]]+).*/\1/p' dev.gesslar.mdv.yml | head -1)
 
 # Flatpak: build mdv against the KDE runtime via flatpak-builder, then bundle a
 # single-file dist/mdv-<version>-<arch>.flatpak. --install-deps-from=flathub
@@ -69,7 +74,7 @@ flatpak:
 	flatpak build-bundle \
 	  --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo \
 	  $(DIST_DIR)/flatpak-repo \
-	  $(DIST_DIR)/mdv-$(MDV_VERSION)-$(MDV_ARCH).flatpak dev.gesslar.mdv
+	  $(DIST_DIR)/mdv-$(MDV_VERSION)-$(MDV_ARCH).flatpak dev.gesslar.mdv $(MDV_BRANCH)
 
 # AppImage: a patchelf-free single-file bundle. scripts/appimage.sh hand-rolls
 # the deploy (pristine libs + a wrapper AppRun) because patchelf corrupts this

--- a/dev.gesslar.mdv.yml
+++ b/dev.gesslar.mdv.yml
@@ -10,6 +10,10 @@
 # (type: git with url + tag + commit) — Flathub builds from a published ref,
 # not a local checkout.
 id: dev.gesslar.mdv
+# The flatpak "branch" is a release-channel label, not a git branch; left unset
+# it defaults to "master". We pin it to match our git default branch. (Flathub
+# expects "stable" for published apps — switch this before a Flathub submission.)
+default-branch: main
 runtime: org.kde.Platform
 runtime-version: '6.9'
 sdk: org.kde.Sdk


### PR DESCRIPTION
## Fix flatpak bundle installation failing due to missing runtime and wrong branch ref

The generated `.flatpak` bundle was broken in two ways:

1. **Missing runtime source**: Installing the bundle on a machine without `org.kde.Platform` already present would fail with `"requires the runtime org.kde.Platform/.../6.9 which was not found"`. The `--runtime-repo` flag is now passed to `flatpak build-bundle`, stamping the Flathub URL into the bundle so flatpak can automatically fetch the required runtime on install.

2. **Wrong branch ref bundled**: `flatpak build-bundle` defaults its branch argument to `master`, causing it to bundle a stale or absent ref instead of the actual build. A `default-branch: main` field has been added to the manifest as the single source of truth, and `MDV_BRANCH` is now extracted from it and passed explicitly to `build-bundle`.

Also bumps the project version to `2.0.1`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two bugs in the flatpak bundle build: adds `--runtime-repo` so the bundle carries the Flathub URL (enabling automatic runtime installation), and passes the correct branch ref extracted from the manifest instead of relying on `flatpak build-bundle`'s `master` default. Also bumps the project version to 2.0.1.

- `dev.gesslar.mdv.yml` gains `default-branch: main` as the single source of truth for the flatpak release channel; a helpful inline note flags that Flathub submissions should use `stable`.
- `Makefile.dist.linux` adds `MDV_BRANCH` (lazily evaluated from the manifest via `sed`, matching the existing pattern for `MDV_VERSION`) and threads it through to `flatpak build-bundle`.
- `CMakeLists.txt` receives a straightforward version bump.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the changes are well-scoped fixups to the flatpak build path with no impact on the application itself.

All three changed files make narrow, targeted corrections. The application source is untouched; the only risk surface is the flatpak packaging path, which is well-commented and follows established patterns in the Makefile.

No files require special attention beyond the single suggestion in Makefile.dist.linux.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AMakefile.dist.linux%3A68-69%0AIf%20%60sed%60%20fails%20to%20match%20%60default-branch%60%20%28field%20renamed%2C%20indented%2C%20or%20file%20unavailable%29%2C%20%60MDV_BRANCH%60%20expands%20to%20the%20empty%20string%20and%20Make%20silently%20omits%20the%20branch%20argument%20%E2%80%94%20causing%20%60flatpak%20build-bundle%60%20to%20fall%20back%20to%20its%20default%20%60master%60%2C%20quietly%20reintroducing%20the%20exact%20bug%20this%20PR%20fixes.%20A%20guard%20in%20the%20recipe%20makes%20the%20failure%20loud%20rather%20than%20invisible.%0A%0A%60%60%60suggestion%0Aflatpak%3A%0A%09%40test%20-n%20%22%24%28MDV_BRANCH%29%22%20%7C%7C%20%5C%0A%09%20%20%7B%20echo%20%22ERROR%3A%20could%20not%20extract%20default-branch%20from%20dev.gesslar.mdv.yml%22%20%3E%262%3B%20exit%201%3B%20%7D%0A%09flatpak-builder%20--force-clean%20--user%20--install-deps-from%3Dflathub%20%5C%0A%60%60%60%0A%0A&repo=gesslar%2Fmdv.qt&pr=16&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["flatpak: brand the bundle &#39;main&#39; not the..."](https://github.com/gesslar/mdv.qt/commit/164cd6652177d51f92e177ed1f00a4f3efa263f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33994960)</sub>

<!-- /greptile_comment -->