### PR TITLE
bump to 2.0.2, normalize deb/rpm artifact filenames to x86_64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(mdv
-    VERSION 2.0.1
+    VERSION 2.0.2
     DESCRIPTION "An offline Markdown viewer for everybody! For free! Huzzah!"
     LANGUAGES CXX
 )

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -41,7 +41,12 @@ if(UNIX AND NOT APPLE)
         "libqt6widgets6 (>= 6.5), libmd4c0, libkf6syntaxhighlighting6")
     set(CPACK_DEBIAN_PACKAGE_SECTION text)
     set(CPACK_DEBIAN_PACKAGE_PRIORITY optional)
-    set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+    # Overridden from DEB-DEFAULT (mdv_<v>_amd64.deb) so every artifact reads
+    # mdv-<v>-x86_64.<ext>, matching the AppImage/flatpak. FILENAME only — the
+    # embedded control Architecture stays "amd64" (Debian-correct), and dpkg/apt
+    # install off that metadata, not the name. The build is pinned x86_64 (docker/),
+    # so the literal arch token is safe.
+    set(CPACK_DEBIAN_FILE_NAME "mdv-${CPACK_PACKAGE_VERSION}-x86_64.deb")
 
     # --- RPM (.rpm) -----------------------------------------------------------
     #
@@ -51,7 +56,10 @@ if(UNIX AND NOT APPLE)
     set(CPACK_RPM_PACKAGE_LICENSE "0BSD")
     set(CPACK_RPM_PACKAGE_GROUP "Applications/Text")
     set(CPACK_RPM_PACKAGE_URL "${CPACK_PACKAGE_HOMEPAGE_URL}")
-    set(CPACK_RPM_FILE_NAME RPM-DEFAULT)
+    # Overridden from RPM-DEFAULT (mdv-<v>-1.x86_64.rpm) to drop the release field
+    # from the FILENAME and match the shared mdv-<v>-x86_64.<ext> shape. The NVR
+    # release ("1") still lives in the embedded metadata, untouched.
+    set(CPACK_RPM_FILE_NAME "mdv-${CPACK_PACKAGE_VERSION}-x86_64.rpm")
     # CPackRPM doesn't fall back to CPACK_PACKAGE_DESCRIPTION (the DEB generator
     # does), so without this the %description is CPack's "created using CPack"
     # boilerplate. Point it at the same text the .deb uses.


### PR DESCRIPTION
## Version 2.0.2: Normalize package artifact filenames

Renames the generated `.deb` and `.rpm` artifact filenames to follow a consistent `mdv-<version>-x86_64.<ext>` pattern, matching the naming convention already used by the AppImage and Flatpak releases.

Previously, CPack's defaults produced `mdv_<version>_amd64.deb` and `mdv-<version>-1.x86_64.rpm`, which differed in separator style and included format-specific tokens (`amd64` vs `x86_64`, and the RPM release field `1`). The embedded package metadata (Debian `Architecture: amd64` and RPM NVR release) remains unchanged, so installation behavior via `dpkg`/`apt`/`rpm` is unaffected — only the output filename changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the version to 2.0.2 and normalizes the output filenames for `.deb` and `.rpm` CPack artifacts to follow the `mdv-<version>-x86_64.<ext>` pattern already used by AppImage and Flatpak releases.

- `CPACK_DEBIAN_FILE_NAME` is overridden from `DEB-DEFAULT` to `"mdv-${CPACK_PACKAGE_VERSION}-x86_64.deb"`, replacing the default `mdv_<v>_amd64.deb` (underscore separators, `amd64` token) with a dash-separated, `x86_64` token filename; embedded Debian control metadata (`Architecture: amd64`) is untouched.
- `CPACK_RPM_FILE_NAME` is overridden from `RPM-DEFAULT` to `"mdv-${CPACK_PACKAGE_VERSION}-x86_64.rpm"`, dropping the release field (`1`) from the filename only; the NVR release in the embedded RPM metadata is also untouched.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it touches only the CPack output filename for .deb and .rpm artifacts without affecting installed package metadata, dependencies, or build logic.

The changes are cosmetic at the filesystem level: the generated filenames change, but the packages themselves install identically because the embedded Debian control and RPM NVR metadata remain unchanged. CPACK_PACKAGE_VERSION is explicitly assigned from PROJECT_VERSION earlier in the same file, so variable expansion is reliable. No logic paths, install rules, or dependency lists were modified.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["packaging: name deb/rpm mdv-&lt;v&gt;-x86\_64 t..."](https://github.com/gesslar/mdv.qt/commit/4ca4deb80df358acfc5f074038c3beba0e5f5eec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33998527)</sub>

<!-- /greptile_comment -->