### PR TITLE
dark titlebar and Mica backdrop on Windows via DWM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,10 @@ qt_add_executable(mdv
 # CMake autoselects windres on MinGW / rc.exe on MSVC.
 if(WIN32)
     target_sources(mdv PRIVATE resources/mdv.rc)
+    # dwmapi: DwmSetWindowAttribute for the Win11 immersive-dark / Mica
+    # titlebar opt-in. Ships with the OS since Vista; safe to link
+    # unconditionally on Windows.
+    target_link_libraries(mdv PRIVATE dwmapi)
 endif()
 
 target_link_libraries(mdv PRIVATE Qt6::Widgets ${MD4C} ${KSH})

--- a/scripts/msix/identity.txt
+++ b/scripts/msix/identity.txt
@@ -1,0 +1,12 @@
+; Microsoft Store / MSIX identity for mdv. These five fields are fixed for
+; the lifetime of the Store listing — they never change between releases.
+; Kept here so scripts/msix/prepare.ps1 (and any future regenerator) has a
+; single canonical source if the base template ever needs to be rebuilt.
+;
+; Source of truth for *what we publish per release* is scripts/msix/base-template.xml.
+
+PackageName        = gesslar.mdv
+PackageDisplayName = mdv
+PublisherName      = CN=BB7C591A-0B88-4F69-A18A-C880C887039A
+PublisherDisplayName = gesslar
+PackageDescription = A fast and free, minimal desktop Markdown viewer.

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -30,6 +30,9 @@
   #ifndef DWMWA_SYSTEMBACKDROP_TYPE
     #define DWMWA_SYSTEMBACKDROP_TYPE 38
   #endif
+  #ifndef DWMSBT_MAINWINDOW
+    #define DWMSBT_MAINWINDOW 2
+  #endif
   #include <windows.h>
   #include <dwmapi.h>
 #endif
@@ -64,7 +67,7 @@ void applyWindowsChrome(QWidget *w) {
   // frame keeps its solid background. Without making the client area
   // transparent the effect is confined to the titlebar/border, but that
   // alone is a noticeable upgrade over the flat solid color.
-  const int backdrop = 2;
+  const int backdrop = DWMSBT_MAINWINDOW;
   DwmSetWindowAttribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE, &backdrop,
                         sizeof(backdrop));
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -19,9 +19,56 @@
 #include "EditorGroup.h"
 #include "PreferencesDialog.h"
 
+#ifdef Q_OS_WIN
+  #include <QGuiApplication>
+  #include <QStyleHints>
+  // Older MinGW SDKs predate these names. Values match the Microsoft DWM docs
+  // and are stable across SDK versions, so the fallbacks are safe.
+  #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+    #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+  #endif
+  #ifndef DWMWA_SYSTEMBACKDROP_TYPE
+    #define DWMWA_SYSTEMBACKDROP_TYPE 38
+  #endif
+  #include <windows.h>
+  #include <dwmapi.h>
+#endif
+
 namespace {
 constexpr int kRecentFilesLimit = 10;
 constexpr const char *kRecentFilesKey = "recentFiles";
+
+#ifdef Q_OS_WIN
+// Qt windows on Windows don't opt into the Win10/11 dark-mode titlebar by
+// default — the system frame stays in the legacy light style even when the
+// rest of the desktop is dark. Opt in via DWM so the titlebar tracks the
+// active Qt color scheme. Older Win10 builds return failure and the frame
+// keeps its prior appearance, so no fallback handling is needed.
+//
+// Note: users who've enabled "Show accent color on title bars and window
+// borders" in Personalization will still see their accent color here — that
+// setting overrides immersive dark mode for traditional Win32 chrome and
+// can't be bypassed without drawing a custom titlebar.
+void applyWindowsChrome(QWidget *w) {
+  const HWND hwnd = reinterpret_cast<HWND>(w->winId());
+  if(!hwnd) return;
+
+  const BOOL dark =
+      QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark
+          ? TRUE
+          : FALSE;
+  DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &dark,
+                        sizeof(dark));
+
+  // DWMSBT_MAINWINDOW (Mica). Pre-22H2 Win11 / Win10 return failure and the
+  // frame keeps its solid background. Without making the client area
+  // transparent the effect is confined to the titlebar/border, but that
+  // alone is a noticeable upgrade over the flat solid color.
+  const int backdrop = 2;
+  DwmSetWindowAttribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE, &backdrop,
+                        sizeof(backdrop));
+}
+#endif
 }  // namespace
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
@@ -148,6 +195,15 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   // the menu closes.
   m_statusLabel = new QLabel(tr("No file open."), this);
   statusBar()->addWidget(m_statusLabel);
+
+#ifdef Q_OS_WIN
+  // winId() forces native HWND creation so the DWM calls have something to
+  // target. Reapply on system theme switches so the titlebar tracks live.
+  (void)winId();
+  applyWindowsChrome(this);
+  connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
+          [this](Qt::ColorScheme) { applyWindowsChrome(this); });
+#endif
 }
 
 MainWindow::~MainWindow() = default;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -22,8 +22,14 @@
 #ifdef Q_OS_WIN
   #include <QGuiApplication>
   #include <QStyleHints>
-  // Older MinGW SDKs predate these names. Values match the Microsoft DWM docs
-  // and are stable across SDK versions, so the fallbacks are safe.
+  #include <windows.h>
+  #include <dwmapi.h>
+  // Fallbacks for older MinGW SDKs that predate these names. Placed AFTER
+  // the SDK headers so that when a future SDK ships the names — as a #define
+  // or, more likely, as DWMWINDOWATTRIBUTE / DWM_SYSTEMBACKDROP_TYPE enum
+  // entries — the SDK version wins. (A #define ahead of the SDK header would
+  // textually replace the enum entry's identifier and break the enum.)
+  // Values match the documented Microsoft DWM constants.
   #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
     #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
   #endif
@@ -33,8 +39,6 @@
   #ifndef DWMSBT_MAINWINDOW
     #define DWMSBT_MAINWINDOW 2
   #endif
-  #include <windows.h>
-  #include <dwmapi.h>
 #endif
 
 namespace {


### PR DESCRIPTION
## Windows Dark Mode Titlebar & Mica Effect

Opts the application window into the Windows dark mode titlebar on Windows 10/11 by calling `DwmSetWindowAttribute` with `DWMWA_USE_IMMERSIVE_DARK_MODE`, so the native frame tracks the active Qt color scheme rather than staying locked to the legacy light style. Also requests the Mica backdrop effect (`DWMSBT_MAINWINDOW`) on Windows 11 22H2+; older builds silently ignore it and retain their solid titlebar background.

The titlebar appearance is reapplied whenever the system color scheme changes at runtime, keeping it in sync with live theme switches. `dwmapi` is linked unconditionally on Windows — it has shipped with the OS since Vista.

Fallback constants for `DWMWA_USE_IMMERSIVE_DARK_MODE` and `DWMWA_SYSTEMBACKDROP_TYPE` are defined for older MinGW SDKs that predate these names; the values are stable and match the Microsoft DWM documentation.

Also adds `scripts/msix/identity.txt` as a canonical reference for the fixed Microsoft Store/MSIX package identity fields.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR opts the application window into the Windows dark-mode titlebar and Mica backdrop by calling `DwmSetWindowAttribute` via `dwmapi`, which ships with every Windows version since Vista. The titlebar dark-mode state is reapplied live on `QStyleHints::colorSchemeChanged`, keeping it in sync with runtime theme switches.

- `CMakeLists.txt` links `dwmapi` inside the existing `WIN32` guard; `MainWindow.cpp` adds the DWM calls behind `Q_OS_WIN`, with correct fallback constant definitions placed after the SDK headers so a future SDK's enum values always win.
- `scripts/msix/identity.txt` adds a canonical reference for the fixed Store/MSIX identity fields so rebuild scripts have a single source of truth.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the DWM changes are well-guarded behind platform ifdefs, the dwmapi link is unconditional only on Windows, and the colorSchemeChanged connection properly uses `this` as context to auto-disconnect on destruction.

The change is cosmetic and platform-isolated. DWM failure return values are silently ignored by design (valid for visual-only features), the HWND validity guard is present, and the lambda receiver lifetime is correctly managed by Qt's connection context mechanism.

No files require special attention; all changes are confined to the Q_OS_WIN / WIN32 preprocessor guards.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2FMainWindow.cpp%3A59-77%0AThe%20%60DWMWA_SYSTEMBACKDROP_TYPE%60%20attribute%20is%20not%20color-scheme-dependent%20%E2%80%94%20Mica%20needs%20to%20be%20requested%20once%20and%20Windows%20will%20automatically%20render%20it%20correctly%20in%20both%20light%20and%20dark%20modes.%20Re-calling%20%60DwmSetWindowAttribute%60%20for%20it%20on%20every%20theme%20switch%20is%20unnecessary%20work%2C%20and%20on%20some%20older%20Win11%20builds%20it%20can%20momentarily%20reset%20the%20backdrop%20before%20re-applying%20it.%20Only%20the%20%60DWMWA_USE_IMMERSIVE_DARK_MODE%60%20attribute%20needs%20to%20change%20when%20the%20scheme%20toggles.%0A%0A%60%60%60suggestion%0Avoid%20applyDarkMode%28QWidget%20*w%29%20%7B%0A%20%20const%20HWND%20hwnd%20%3D%20reinterpret_cast%3CHWND%3E%28w-%3EwinId%28%29%29%3B%0A%20%20if%28!hwnd%29%20return%3B%0A%0A%20%20const%20BOOL%20dark%20%3D%0A%20%20%20%20%20%20QGuiApplication%3A%3AstyleHints%28%29-%3EcolorScheme%28%29%20%3D%3D%20Qt%3A%3AColorScheme%3A%3ADark%0A%20%20%20%20%20%20%20%20%20%20%3F%20TRUE%0A%20%20%20%20%20%20%20%20%20%20%3A%20FALSE%3B%0A%20%20DwmSetWindowAttribute%28hwnd%2C%20DWMWA_USE_IMMERSIVE_DARK_MODE%2C%20%26dark%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20sizeof%28dark%29%29%3B%0A%7D%0A%0Avoid%20applyWindowsChrome%28QWidget%20*w%29%20%7B%0A%20%20applyDarkMode%28w%29%3B%0A%0A%20%20%2F%2F%20DWMSBT_MAINWINDOW%20%28Mica%29.%20Pre-22H2%20Win11%20%2F%20Win10%20return%20failure%20and%20the%0A%20%20%2F%2F%20frame%20keeps%20its%20solid%20background.%20Without%20making%20the%20client%20area%0A%20%20%2F%2F%20transparent%20the%20effect%20is%20confined%20to%20the%20titlebar%2Fborder%2C%20but%20that%0A%20%20%2F%2F%20alone%20is%20a%20noticeable%20upgrade%20over%20the%20flat%20solid%20color.%0A%20%20const%20HWND%20hwnd%20%3D%20reinterpret_cast%3CHWND%3E%28w-%3EwinId%28%29%29%3B%0A%20%20if%28!hwnd%29%20return%3B%0A%20%20const%20int%20backdrop%20%3D%20DWMSBT_MAINWINDOW%3B%0A%20%20DwmSetWindowAttribute%28hwnd%2C%20DWMWA_SYSTEMBACKDROP_TYPE%2C%20%26backdrop%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20sizeof%28backdrop%29%29%3B%0A%7D%0A%60%60%60%0A%0A&repo=gesslar%2Fmdv.qt&pr=18&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["review: order DWM fallback defines after..."](https://github.com/gesslar/mdv.qt/commit/e7ef9f98cdb30d335225c913c132f1550363cd34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34249404)</sub>

<!-- /greptile_comment -->