### PR TITLE
build: require qt6-qtbase-private-devel on Linux for QWindowKit

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -22,7 +22,7 @@
 ### Fedora
 
 ```bash
-sudo dnf install qt6-qtbase-devel md4c-devel kf6-syntax-highlighting-devel cmake ninja-build gcc-c++
+sudo dnf install qt6-qtbase-devel qt6-qtbase-private-devel md4c-devel kf6-syntax-highlighting-devel cmake ninja-build gcc-c++
 ```
 
 Add `qt-creator gdb clang-tools-extra` if you want the IDE and debugger.
@@ -30,7 +30,7 @@ Add `qt-creator gdb clang-tools-extra` if you want the IDE and debugger.
 ### Debian / Ubuntu
 
 ```bash
-sudo apt install qt6-base-dev libmd4c-dev libkf6syntaxhighlighting-dev cmake ninja-build g++
+sudo apt install qt6-base-dev qt6-base-private-dev libmd4c-dev libkf6syntaxhighlighting-dev cmake ninja-build g++
 # Optional IDE:
 sudo apt install qtcreator
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ FROM --platform=linux/amd64 fedora:44
 # metainfo derives its release date from `git log`) + the appdir-lint deps
 # (desktop-file-validate, appstreamcli, mimetype, which).
 RUN dnf install -y --setopt=install_weak_deps=False \
-      qt6-qtbase-devel kf6-syntax-highlighting-devel md4c-devel \
+      qt6-qtbase-devel qt6-qtbase-private-devel kf6-syntax-highlighting-devel md4c-devel \
       extra-cmake-modules cmake ninja-build gcc-c++ git \
       flatpak flatpak-builder dpkg rpm-build \
       desktop-file-utils appstream perl-File-MimeInfo file which curl \

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -12,6 +12,7 @@
 #include <QStatusBar>
 #include <QToolButton>
 #include <QUrl>
+#include <QVBoxLayout>
 
 #include "ContentTheme.h"
 #include "DocumentView.h"
@@ -32,8 +33,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   setWindowTitle(tr("mdv"));
   resize(900, 600);
 
+  // m_area is placed into a container central widget at the end of this
+  // constructor, alongside the custom title bar.
   m_area = new EditorArea(this);
-  setCentralWidget(m_area);
   connect(m_area, &EditorArea::currentDocumentChanged, this,
           &MainWindow::onCurrentDocumentChanged);
   connect(m_area, &EditorArea::filesDropped, this,
@@ -165,6 +167,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   // and tell QWK which children are the system buttons (so it knows where
   // the maximize hover popout anchors) and which are interactive (so they
   // get clicks instead of treating the whole strip as a drag zone).
+  //
+  // Set up the window agent FIRST (it reworks the native window into a
+  // frameless one), then build the title bar and register it.
+  auto *agent = new QWK::WidgetWindowAgent(this);
+  agent->setup(this);
+
   auto *titleBar = new TitleBar(this);
   titleBar->setFileMenu(fileMenu);
   titleBar->setViewMenu(viewMenu);
@@ -176,10 +184,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
     else showMaximized();
   });
   connect(titleBar, &TitleBar::closeClicked, this, &QWidget::close);
-  setMenuWidget(titleBar);
 
-  auto *agent = new QWK::WidgetWindowAgent(this);
-  agent->setup(this);
   agent->setTitleBar(titleBar);
   agent->setSystemButton(QWK::WindowAgentBase::Minimize, titleBar->minButton());
   agent->setSystemButton(QWK::WindowAgentBase::Maximize, titleBar->maxButton());
@@ -187,6 +192,22 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   agent->setHitTestVisible(titleBar->fileButton(), true);
   agent->setHitTestVisible(titleBar->viewButton(), true);
   agent->setHitTestVisible(titleBar->settingsButton(), true);
+
+  // Install the title bar as the top of a container central widget rather than
+  // via setMenuWidget(). On KDE the Plasma platform theme lazily creates a
+  // QMenuBar and installs it in QMainWindow's menu-bar slot; that eviction
+  // deletes a title bar parked there with setMenuWidget(), leaving the window
+  // with no title bar (and dangling QWK button pointers). Keeping the menu-bar
+  // slot empty and stacking [title bar | editor area] in the central widget
+  // sidesteps the contention — QWK only needs setTitleBar() above for the drag
+  // region, not a particular place in the layout.
+  auto *container = new QWidget(this);
+  auto *layout = new QVBoxLayout(container);
+  layout->setContentsMargins(0, 0, 0, 0);
+  layout->setSpacing(0);
+  layout->addWidget(titleBar);
+  layout->addWidget(m_area, 1);
+  setCentralWidget(container);
 }
 
 MainWindow::~MainWindow() = default;


### PR DESCRIPTION
QWindowKit (custom titlebar) compiles against Qt6 private + QPA headers,
which on Linux ship in a separate package (Fedora qt6-qtbase-private-devel,
Debian qt6-base-private-dev) not pulled in by qt6-qtbase-devel. Add it to
the DEVELOPMENT.md install lists and the make-linux Docker clean-room.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the Linux Qt6 private-headers package (`qt6-qtbase-private-devel` / `qt6-base-private-dev`) to both the developer docs and the Fedora Docker clean-room build, and refactors `MainWindow` to fix a KDE Plasma crash where the platform theme evicts the custom title bar from the `setMenuWidget` slot.

- **Build fix**: `qt6-qtbase-private-devel` (Fedora) and `qt6-base-private-dev` (Debian) are added to `DEVELOPMENT.md` install commands and the `docker/Dockerfile` `dnf` call so QWindowKit's private + QPA header dependency is satisfied on Linux.
- **KDE compatibility fix**: The window agent is now set up before the title bar widget is registered (correct ordering for frameless-window transformation), and the title bar is stacked inside a `QVBoxLayout` container set as the central widget instead of occupying the `setMenuWidget` slot — sidestepping the KDE Plasma lazy-QMenuBar eviction that previously left dangling QWK button pointers.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three changes are narrowly scoped dependency and layout fixes with no regressions in the normal code path.

The package additions are straightforward and consistent across DEVELOPMENT.md and the Dockerfile. The MainWindow refactor is well-reasoned: moving agent->setup() before titleBar construction respects QWindowKit's required ordering, and using a QVBoxLayout central widget instead of setMenuWidget() correctly avoids the KDE Plasma lazy-QMenuBar eviction. Qt's addWidget() reparenting handles ownership cleanly, and no central widget is needed until after the constructor completes (the window isn't shown mid-constructor).

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["build: require qt6-qtbase-private-devel ..."](https://github.com/gesslar/mdv.qt/commit/84e0c6b3587db3e53a5d9c6edc46c88e826f8cc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34274803)</sub>

<!-- /greptile_comment -->