### PR TITLE
build: declare Qt6 private components to silence QWindowKit linking warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,23 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type" FORCE)
 endif()
 
-find_package(Qt6 6.5 REQUIRED COMPONENTS Widgets)
+# The *Private components are pulled in for QWindowKit (below): its frameless
+# contexts compile against Qt's private/QPA headers. QWindowKit finds those
+# private targets inside a function scope (via qmsetup), so the imported
+# Qt6::*Private targets aren't visible when Qt finalizes the mdv target — which
+# prints "<X>Private ... mentioned as a dependency ... but not declared"
+# warnings (and potentially incomplete linking) as it walks QWKCore's /
+# QWindowKit::Widgets's link interface. Declaring them here at top level makes
+# the targets exist project-wide. (On Linux these need qt6-qtbase-private-devel;
+# see DEVELOPMENT.md.)
+#
+# Depending on private Qt API is unavoidable with QWindowKit and is its
+# maintainers' burden to track across Qt versions; we knowingly accept it, so
+# suppress Qt's per-module "you are using a private module" advisory rather than
+# have it fire three times on every configure.
+set(QT_NO_PRIVATE_MODULE_WARNING ON)
+find_package(Qt6 6.5 REQUIRED
+    COMPONENTS Widgets CorePrivate GuiPrivate WidgetsPrivate)
 
 # --- Non-Qt dependencies ------------------------------------------------------
 #


### PR DESCRIPTION
Adds `CorePrivate`, `GuiPrivate`, and `WidgetsPrivate` to the Qt6 `find_package` call to satisfy QWindowKit's dependency on Qt's private/QPA headers. Without these targets declared at the top-level CMake scope, Qt's finalization step for the `mdv` target emits warnings about undeclared private module dependencies and may produce incomplete linking.

Sets `QT_NO_PRIVATE_MODULE_WARNING` to suppress Qt's advisory about private module usage, since reliance on private Qt API is an inherent and accepted aspect of using QWindowKit.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the top-level `find_package(Qt6 ...)` call to explicitly include `CorePrivate`, `GuiPrivate`, and `WidgetsPrivate` components and sets `QT_NO_PRIVATE_MODULE_WARNING` to silence Qt's advisory about private module use. The change resolves CMake finalization warnings (and potential incomplete linking) that arise because QWindowKit consumes Qt private/QPA headers but registers those dependencies inside a nested function scope where the project-level targets are not visible.

- `CorePrivate`, `GuiPrivate`, and `WidgetsPrivate` are now declared at project scope so Qt's target finalization for `mdv` can resolve QWindowKit's transitive private-module link interface without warnings.
- `QT_NO_PRIVATE_MODULE_WARNING` is set before the `find_package` call to prevent the three per-module advisories that would otherwise fire on every configure, with the rationale captured in a detailed comment block.

<h3>Confidence Score: 5/5</h3>

The change is a focused, additive build system fix — it adds private Qt components to an existing `find_package` call and sets a suppression variable before that call. No logic, no runtime behavior, and no existing targets are altered.

The change is confined to three lines in CMakeLists.txt: a `set()` before `find_package` and two added component names. The placement of `QT_NO_PRIVATE_MODULE_WARNING` before the `find_package` call is correct. Making the private components `REQUIRED` is appropriate since QWindowKit already requires them — a missing `qt6-qtbase-private-devel` package (Linux) will now produce a clear configure error instead of an obscure link failure. The comment block is thorough and the DEVELOPMENT.md reference covers the new Linux dependency. No behavioral regressions are possible from this change.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["build: declare Qt6 \*Private targets to s..."](https://github.com/gesslar/mdv.qt/commit/179100a6fddf4f681f5d6517d8fd4f6cfb6ee0ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34279731)</sub>

<!-- /greptile_comment -->