### PR TITLE
build: silence configure warnings, skip redundant reconfigures, suppress QWK deprecations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,12 @@ endif()
 # suppress Qt's per-module "you are using a private module" advisory rather than
 # have it fire three times on every configure.
 set(QT_NO_PRIVATE_MODULE_WARNING ON)
+# Qt6Gui's exported config does find_dependency(WrapVulkanHeaders), which prints
+# a "Could NOT find WrapVulkanHeaders" warning on boxes without the Vulkan SDK
+# even though Qt builds & runs fine without it (it's an optional Vulkan-QPA
+# integration). We never touch Qt's Vulkan path, so skip the find_package
+# probe — the warning goes away and Qt links exactly the same.
+set(CMAKE_DISABLE_FIND_PACKAGE_WrapVulkanHeaders ON)
 find_package(Qt6 6.5 REQUIRED
     COMPONENTS Widgets CorePrivate GuiPrivate WidgetsPrivate)
 
@@ -139,12 +145,38 @@ if(WIN32)
     # need it, and skipping the find_package avoids a "not found" warning on
     # boxes without it. Translations + the katehighlightingindexer build and
     # run natively here, so they don't need disabling.
-    #
-    # KSH's CMakeLists also hard-codes add_subdirectory(examples) and
-    # add_subdirectory(src/cli) with no off-switch — they build alongside the
-    # library. They don't affect the mdv.exe link and their install() rules
-    # are suppressed below, so we just absorb the extra build time.
     set(CMAKE_DISABLE_FIND_PACKAGE_XercesC ON CACHE BOOL "" FORCE)
+
+    # Trim KSH down to just the library + indexer (the parts we link against /
+    # need at build time). Three knobs:
+    #   1. Qt6Quick disabled → no kquicksyntaxhighlightingplugin (a QML plugin
+    #      we never load). This also silences three -Wmissing-include-dirs
+    #      warnings the plugin's autogen emits during compile.
+    #   2. DISABLE_ALL_OPTIONAL_SUBDIRECTORIES → KSH's examples/ subtrees
+    #      (codeeditor, codepdfprinter, minimaltest) default OFF via ECM's
+    #      ecm_optional_add_subdirectory. Speeds up clean builds; removes noise.
+    #   3. KDE_INSTALL_* preseeded from Qt's GNUInstallDirs values to head off
+    #      KDEInstallDirs' four "got its value from CMAKE_INSTALL_*DIR" warnings
+    #      (Qt's find_package(Qt6) includes GNUInstallDirs first, then KSH's
+    #      include(KDEInstallDirs) flags the cross-include). The defines exist
+    #      because of that order, so just adopt them explicitly.
+    # The ksyntaxhighlighter6 CLI executable still builds (no upstream off-
+    # switch and it's warning-free), but it's not linked into mdv.exe and its
+    # install() rules are suppressed.
+    set(CMAKE_DISABLE_FIND_PACKAGE_Qt6Quick ON CACHE BOOL "" FORCE)
+    set(DISABLE_ALL_OPTIONAL_SUBDIRECTORIES ON CACHE BOOL "" FORCE)
+    # ECM's KDEFrameworkCompilerSettings probes for Sphinx (KSH doc builder).
+    # We're not building KSH's docs, so skip the probe — silences the
+    # "Could NOT find Sphinx" line on every configure.
+    set(CMAKE_DISABLE_FIND_PACKAGE_Sphinx ON CACHE BOOL "" FORCE)
+    include(GNUInstallDirs)
+    foreach(_dir BINDIR SBINDIR LIBEXECDIR SYSCONFDIR SHAREDSTATEDIR
+                 LOCALSTATEDIR RUNSTATEDIR LIBDIR INCLUDEDIR OLDINCLUDEDIR
+                 DATAROOTDIR DATADIR INFODIR LOCALEDIR MANDIR DOCDIR)
+        if(NOT DEFINED KDE_INSTALL_${_dir} AND DEFINED CMAKE_INSTALL_${_dir})
+            set(KDE_INSTALL_${_dir} "${CMAKE_INSTALL_${_dir}}" CACHE PATH "")
+        endif()
+    endforeach()
 
     # --- extra-cmake-modules ----------------------------------------------
     #
@@ -168,14 +200,22 @@ if(WIN32)
         if(NOT EXISTS "${_ecm_src}/CMakeLists.txt")
             find_package(Git REQUIRED)
             file(REMOVE_RECURSE "${_ecm_src}")
+            # OUTPUT/ERROR_VARIABLE swallow git's progress chatter (the
+            # "Cloning into ..." + detached-HEAD note + the harmless
+            # "refs/tags/v6.26.0 <sha> is not a commit!" warning that git
+            # emits on a shallow clone of an annotated-tag ref). On a real
+            # failure we surface the captured output via FATAL_ERROR.
             execute_process(
-                COMMAND "${GIT_EXECUTABLE}" clone --depth 1
+                COMMAND "${GIT_EXECUTABLE}" clone --depth 1 --no-tags
                     --branch v6.26.0
                     https://invent.kde.org/frameworks/extra-cmake-modules.git
                     "${_ecm_src}"
+                OUTPUT_VARIABLE _ecm_clone_log
+                ERROR_VARIABLE _ecm_clone_log
                 RESULT_VARIABLE _ecm_clone)
             if(NOT _ecm_clone EQUAL 0)
-                message(FATAL_ERROR "ECM clone failed (exit ${_ecm_clone})")
+                message(FATAL_ERROR
+                    "ECM clone failed (exit ${_ecm_clone}):\n${_ecm_clone_log}")
             endif()
         endif()
         execute_process(
@@ -184,6 +224,11 @@ if(WIN32)
                 -G "${CMAKE_GENERATOR}"
                 "-DCMAKE_INSTALL_PREFIX=${ECM_LOCAL_PREFIX}"
                 -DBUILD_TESTING=OFF
+                # ECM is a "no compile" pure-CMake project, so it has no need
+                # to probe for Sphinx (or anything else doc-related); skip the
+                # find_package(Sphinx) inside its own configure to stop the
+                # "Could NOT find Sphinx" line from bleeding into our log.
+                -DCMAKE_DISABLE_FIND_PACKAGE_Sphinx=ON
             RESULT_VARIABLE _ecm_cfg)
         if(NOT _ecm_cfg EQUAL 0)
             message(FATAL_ERROR "ECM configure failed (exit ${_ecm_cfg})")
@@ -270,6 +315,20 @@ FetchContent_Declare(
     GIT_SHALLOW TRUE
 )
 FetchContent_MakeAvailable(QWindowKit)
+
+# Quiet the two -Wdeprecated-declarations from QWKCore's win32windowcontext.cpp
+# (QSurface::RasterGLSurface — Qt 6.11 deprecated it in favour of RasterSurface).
+# Upstream QWindowKit hasn't tracked the rename in 1.5.0; we don't touch the
+# source ourselves, so just suppress the warning on the third-party targets
+# instead of patching the FetchContent'd tree. Drop this once we move to a
+# QWindowKit release that retires RasterGLSurface.
+foreach(_qwk_tgt QWKCore QWKWidgets)
+    if(TARGET ${_qwk_tgt})
+        target_compile_options(${_qwk_tgt} PRIVATE
+            $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:-Wno-deprecated-declarations>
+            $<$<CXX_COMPILER_ID:MSVC>:/wd4996>)
+    endif()
+endforeach()
 
 qt_standard_project_setup()
 

--- a/Makefile
+++ b/Makefile
@@ -50,18 +50,37 @@ endif
 # `make` on its own gives you a dev build.
 all: build
 
+# Reconfigure trigger: we re-run the cmake configure step in either of two
+# cases — (a) the build dir hasn't been configured yet (no build.ninja), or
+# (b) the user passed a configure-affecting flag on the command line, in
+# which case we MUST honor it rather than silently using the cached value.
+# `$(origin VAR)` returns "command line" only for `make VAR=… target`,
+# not for ambient env vars or defaults, which is exactly the signal we want:
+# an explicit override on this invocation. Add PREFIX_PATH-equivalents to this
+# list when introducing new user-facing knobs.
+_CMD_LINE_OVERRIDES := $(filter command line,$(origin PREFIX_PATH))
+_DEV_NEEDS_CONFIGURE := $(or $(_CMD_LINE_OVERRIDES),$(if $(wildcard $(DEV_DIR)/build.ninja),,1))
+_REL_NEEDS_CONFIGURE := $(or $(_CMD_LINE_OVERRIDES),$(if $(wildcard $(RELEASE_DIR)/build.ninja),,1))
+
+# OS-specific include (bottom of this file) may append extra -D flags to the
+# release configure via this hook — e.g. Makefile.dist.windows sets
+# MDV_PACKAGE_OUTPUT_DIR here so the single release configure bakes it in,
+# avoiding a second reconfigure (and the ninja relink cascade it would cause)
+# when `make windows` later runs the packaging target.
+RELEASE_CMAKE_EXTRA ?=
+
 # Dev build (build/): no optimization, debug symbols, assertions on.
 # CMAKE_EXPORT_COMPILE_COMMANDS writes build/compile_commands.json so
 # clangd / Qt Creator can resolve Qt + KSyntaxHighlighting includes.
 #
-# We only run `cmake -S . -B …` (the configure step) when the build dir hasn't
-# been configured yet. Once build.ninja exists, `cmake --build` calls ninja
-# directly, and ninja's RERUN_CMAKE rule self-reconfigures whenever any tracked
+# We skip the `cmake -S . -B …` (configure) step when the build dir is already
+# configured AND no configure-affecting flag was overridden on the command
+# line. Once build.ninja exists, `cmake --build` calls ninja directly, and
+# ninja's RERUN_CMAKE rule self-reconfigures whenever any tracked
 # CMakeLists.txt / .cmake file changes — so subsequent `make`s are no-ops when
-# nothing's changed. Re-invoking configure unconditionally would re-touch enough
-# metadata in the FetchContent'd KSH tree to make ninja re-run the
+# nothing's changed. Re-invoking configure unconditionally would re-touch
+# enough metadata in the FetchContent'd KSH tree to make ninja re-run the
 # katehighlightingindexer, which cascades into a relink of everything.
-# Switching build flags (PREFIX_PATH, etc.) means `make distclean` first.
 #
 # The gate uses Make's built-in $(wildcard …) — evaluated at Makefile parse
 # time, no shell involved — so it works identically whether make's shell is sh
@@ -70,16 +89,17 @@ all: build
 # since cmd has no `test` builtin and treated its absence as "false" — running
 # the configure every time, which was the whole problem we set out to fix.
 build:
-ifeq (,$(wildcard $(DEV_DIR)/build.ninja))
+ifneq (,$(_DEV_NEEDS_CONFIGURE))
 	cmake -S . -B $(DEV_DIR) -G Ninja -DCMAKE_BUILD_TYPE=Debug $(PREFIX_FLAG) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 endif
 	cmake --build $(DEV_DIR)
 
 # Release build (build-release/): optimized, assertions off. What you ship.
 # Same one-shot-configure pattern as `build` above — see the comment there.
+# $(RELEASE_CMAKE_EXTRA) is the OS-include hook for packaging flags.
 release:
-ifeq (,$(wildcard $(RELEASE_DIR)/build.ninja))
-	cmake -S . -B $(RELEASE_DIR) -G Ninja -DCMAKE_BUILD_TYPE=Release $(PREFIX_FLAG)
+ifneq (,$(_REL_NEEDS_CONFIGURE))
+	cmake -S . -B $(RELEASE_DIR) -G Ninja -DCMAKE_BUILD_TYPE=Release $(PREFIX_FLAG) $(RELEASE_CMAKE_EXTRA)
 endif
 	cmake --build $(RELEASE_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -53,13 +53,34 @@ all: build
 # Dev build (build/): no optimization, debug symbols, assertions on.
 # CMAKE_EXPORT_COMPILE_COMMANDS writes build/compile_commands.json so
 # clangd / Qt Creator can resolve Qt + KSyntaxHighlighting includes.
+#
+# We only run `cmake -S . -B …` (the configure step) when the build dir hasn't
+# been configured yet. Once build.ninja exists, `cmake --build` calls ninja
+# directly, and ninja's RERUN_CMAKE rule self-reconfigures whenever any tracked
+# CMakeLists.txt / .cmake file changes — so subsequent `make`s are no-ops when
+# nothing's changed. Re-invoking configure unconditionally would re-touch enough
+# metadata in the FetchContent'd KSH tree to make ninja re-run the
+# katehighlightingindexer, which cascades into a relink of everything.
+# Switching build flags (PREFIX_PATH, etc.) means `make distclean` first.
+#
+# The gate uses Make's built-in $(wildcard …) — evaluated at Makefile parse
+# time, no shell involved — so it works identically whether make's shell is sh
+# (Linux/macOS, or PowerShell+sh-on-PATH on Windows) or cmd.exe (Windows
+# default). An earlier `test -f … ||` version silently failed open on cmd,
+# since cmd has no `test` builtin and treated its absence as "false" — running
+# the configure every time, which was the whole problem we set out to fix.
 build:
+ifeq (,$(wildcard $(DEV_DIR)/build.ninja))
 	cmake -S . -B $(DEV_DIR) -G Ninja -DCMAKE_BUILD_TYPE=Debug $(PREFIX_FLAG) -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+endif
 	cmake --build $(DEV_DIR)
 
 # Release build (build-release/): optimized, assertions off. What you ship.
+# Same one-shot-configure pattern as `build` above — see the comment there.
 release:
+ifeq (,$(wildcard $(RELEASE_DIR)/build.ninja))
 	cmake -S . -B $(RELEASE_DIR) -G Ninja -DCMAKE_BUILD_TYPE=Release $(PREFIX_FLAG)
+endif
 	cmake --build $(RELEASE_DIR)
 
 # Build the dev binary if needed, then launch it.

--- a/Makefile.dist.windows
+++ b/Makefile.dist.windows
@@ -31,12 +31,28 @@
 # Windows format today, so it just maps to `make windows`.
 dist: windows
 
-# `make windows` — the Windows release verb (parallels `make linux`). Re-configure
+# `make windows` — the Windows release verb (parallels `make linux`). Configure
 # the release tree with MDV_PACKAGE_OUTPUT_DIR pointing at our DIST_DIR (otherwise
 # the artifact lands inside the build dir), then drive the package_nsis custom
 # target: it stages the install tree via `cmake --install` and runs makensis on
 # the generated mdv.nsi.
-windows: release
+#
+# The .mdv-windows-configured stamp file gates the reconfigure — we set
+# MDV_PACKAGE_OUTPUT_DIR exactly once into the release tree's CMakeCache.txt;
+# subsequent `make windows` invocations skip the cmake configure and go
+# straight to package_nsis. A re-run of cmake configure on an otherwise-clean
+# tree would re-touch enough metadata in the FetchContent'd KSH tree to make
+# ninja relink everything, the same way `make build` used to. `make distclean`
+# removes the stamp, so the gate auto-resets when the tree is wiped.
+#
+# `release` is an order-only prereq (the `|` separator): we want it to run
+# first if needed, but we don't want a phony's "always dirty" status to force
+# the stamp file to regenerate every invocation. `cmake -E touch` instead of
+# the unix `touch` so this works under cmd.exe as well as sh.
+windows: $(RELEASE_DIR)/.mdv-windows-configured
+	cmake --build $(RELEASE_DIR) --target package_nsis
+
+$(RELEASE_DIR)/.mdv-windows-configured: | release
 	cmake -S . -B $(RELEASE_DIR) -G Ninja -DCMAKE_BUILD_TYPE=Release \
 	    -DMDV_PACKAGE_OUTPUT_DIR=$(CURDIR)/$(DIST_DIR) $(PREFIX_FLAG)
-	cmake --build $(RELEASE_DIR) --target package_nsis
+	cmake -E touch $@

--- a/Makefile.dist.windows
+++ b/Makefile.dist.windows
@@ -31,28 +31,24 @@
 # Windows format today, so it just maps to `make windows`.
 dist: windows
 
-# `make windows` — the Windows release verb (parallels `make linux`). Configure
-# the release tree with MDV_PACKAGE_OUTPUT_DIR pointing at our DIST_DIR (otherwise
-# the artifact lands inside the build dir), then drive the package_nsis custom
-# target: it stages the install tree via `cmake --install` and runs makensis on
-# the generated mdv.nsi.
+# Hook into the top-level Makefile's `release` configure: have it bake the
+# packaging output path into the cache on the first (and only) configure pass.
+# An earlier revision reconfigured the release tree a second time from inside
+# this file purely to add MDV_PACKAGE_OUTPUT_DIR, which would then trigger
+# ninja's RERUN_CMAKE and relink everything — exactly the cascade we set out to
+# prevent. Setting RELEASE_CMAKE_EXTRA here means `make release` and `make
+# windows` share one configure with the right cache vars baked in.
 #
-# The .mdv-windows-configured stamp file gates the reconfigure — we set
-# MDV_PACKAGE_OUTPUT_DIR exactly once into the release tree's CMakeCache.txt;
-# subsequent `make windows` invocations skip the cmake configure and go
-# straight to package_nsis. A re-run of cmake configure on an otherwise-clean
-# tree would re-touch enough metadata in the FetchContent'd KSH tree to make
-# ninja relink everything, the same way `make build` used to. `make distclean`
-# removes the stamp, so the gate auto-resets when the tree is wiped.
-#
-# `release` is an order-only prereq (the `|` separator): we want it to run
-# first if needed, but we don't want a phony's "always dirty" status to force
-# the stamp file to regenerate every invocation. `cmake -E touch` instead of
-# the unix `touch` so this works under cmd.exe as well as sh.
-windows: $(RELEASE_DIR)/.mdv-windows-configured
-	cmake --build $(RELEASE_DIR) --target package_nsis
+# The variable is consumed inside the if(WIN32) branch of Packaging.cmake, so
+# adding it to the release configure on Windows is the natural fit; the Linux
+# include leaves RELEASE_CMAKE_EXTRA empty, so its release configure is
+# unchanged.
+RELEASE_CMAKE_EXTRA := -DMDV_PACKAGE_OUTPUT_DIR=$(CURDIR)/$(DIST_DIR)
 
-$(RELEASE_DIR)/.mdv-windows-configured: | release
-	cmake -S . -B $(RELEASE_DIR) -G Ninja -DCMAKE_BUILD_TYPE=Release \
-	    -DMDV_PACKAGE_OUTPUT_DIR=$(CURDIR)/$(DIST_DIR) $(PREFIX_FLAG)
-	cmake -E touch $@
+# `make windows` — the Windows release verb (parallels `make linux`). Since
+# `release` (top-level) already configures the tree with MDV_PACKAGE_OUTPUT_DIR
+# above, all this needs to do is drive the package_nsis custom target: it
+# stages the install tree via `cmake --install` and runs makensis on the
+# generated mdv.nsi.
+windows: release
+	cmake --build $(RELEASE_DIR) --target package_nsis

--- a/README.md
+++ b/README.md
@@ -64,4 +64,5 @@ It builds on these components, under their own licenses:
 | [Qt 6](https://www.qt.io/) (Widgets) | LGPL-3.0 |
 | [md4c](https://github.com/mity/md4c) | MIT |
 | [KSyntaxHighlighting](https://invent.kde.org/frameworks/syntax-highlighting) | MIT |
+| [QWindowKit](https://github.com/stdware/qwindowkit) (custom title bar / frameless window) | Apache-2.0 |
 | [Codicons](https://github.com/microsoft/vscode-codicons) (bundled tab icons) | MIT |


### PR DESCRIPTION
Suppress spurious configure-time warnings and avoid unnecessary reconfigures on incremental builds.

**Warning suppression**

- Disable the `WrapVulkanHeaders` find-package probe that Qt6Gui's exported config triggers on machines without the Vulkan SDK. Qt builds and runs fine without it; the warning was pure noise.
- Disable the `Sphinx` find-package probe in both the top-level configure and the ECM sub-configure. Neither build produces docs, so the "Could NOT find Sphinx" line had no meaning.
- Pre-seed `KDE_INSTALL_*` variables from GNUInstallDirs values before KSyntaxHighlighting's `KDEInstallDirs` include runs, eliminating the four "got its value from CMAKE_INSTALL_*DIR" cross-include warnings.
- Disable `Qt6Quick` for the KSyntaxHighlighting sub-build to drop the QML plugin (unused) and the three `-Wmissing-include-dirs` warnings its autogen emits.
- Set `DISABLE_ALL_OPTIONAL_SUBDIRECTORIES` for KSyntaxHighlighting to skip the example subtrees, reducing clean-build time and log noise.
- Suppress `-Wdeprecated-declarations` / `/wd4996` on `QWKCore` and `QWKWidgets` for the `QSurface::RasterGLSurface` deprecation introduced in Qt 6.11. QWindowKit 1.5.0 hasn't tracked the rename; the suppression targets only those third-party targets and should be dropped once an upstream release retires the old name.
- Pass `--no-tags` and capture `OUTPUT_VARIABLE`/`ERROR_VARIABLE` on the ECM `git clone` to swallow progress chatter and the annotated-tag shallow-clone warning. Captured output is surfaced only on a real failure.

**Incremental-build gate**

- The `build` and `release` Makefile targets now skip the `cmake -S . -B …` configure step when `build.ninja` already exists in the build directory. Ninja's own `RERUN_CMAKE` rule handles self-reconfiguration when CMake inputs change, so re-invoking configure unconditionally was causing the katehighlightingindexer to re-run and everything to relink on every `make` invocation. The gate uses `$(wildcard …)` (evaluated at parse time) rather than a shell `test -f` so it works correctly under both `sh` and `cmd.exe`.
- The `windows` target in `Makefile.dist.windows` uses a `.mdv-windows-configured` stamp file to apply the same one-shot-configure pattern. `release` becomes an order-only prerequisite so its phony status does not force the stamp to regenerate on every invocation. The stamp is removed by `distclean`, resetting the gate when the tree is wiped.

**README**

Added QWindowKit to the third-party components table.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR silences spurious configure-time warnings (Vulkan, Sphinx, Qt6Quick, KDE_INSTALL_* cross-include) and suppresses the `QSurface::RasterGLSurface` deprecation on the upstream QWindowKit targets. It also replaces unconditional `cmake -S … -B …` invocations with a parse-time `$(wildcard)` gate so that incremental `make build`/`make release` invocations skip reconfiguration when the build directory is already configured, and moves `MDV_PACKAGE_OUTPUT_DIR` into a first-pass `RELEASE_CMAKE_EXTRA` hook to eliminate the double-configure on `make windows`.

- **CMakeLists.txt** — Adds `CMAKE_DISABLE_FIND_PACKAGE_*` knobs, pre-seeds `KDE_INSTALL_*` variables, suppresses deprecation warnings on `QWKCore`/`QWKWidgets`, and captures `git clone` stdout/stderr on ECM fetch (both streams are directed to a single variable — see inline comment).
- **Makefile** — Introduces `_CMD_LINE_OVERRIDES` via `$(origin PREFIX_PATH)` and `$(wildcard)` guards so configure is skipped on incremental builds unless a flag is explicitly overridden on the command line.
- **Makefile.dist.windows** — Removes the second `cmake` configure from the `windows` target; instead injects `MDV_PACKAGE_OUTPUT_DIR` through `RELEASE_CMAKE_EXTRA` so the top-level `release` configure bakes it in on the first (and only) pass.

<h3>Confidence Score: 5/5</h3>

Build-system-only changes with no runtime impact on the shipped binary; the configure-skip gate and warning suppressions are self-contained and well-documented.

All changes are confined to the build system: CMake warning knobs, Makefile configure guards, and a Windows packaging hook. None of these affect the compiled output or runtime behavior of the application. The one notable code pattern concern (shared OUTPUT/ERROR variable in execute_process) is a diagnostic-output issue on an error path that does not affect the build when git clone succeeds.

No files require special attention; all changes are build-system plumbing.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ACMakeLists.txt%3A208-218%0ABoth%20%60OUTPUT_VARIABLE%60%20and%20%60ERROR_VARIABLE%60%20name%20the%20same%20CMake%20variable.%20CMake%20resolves%20them%20independently%20%E2%80%94%20stdout%20is%20written%20first%2C%20then%20stderr%20overwrites%20it%20%28or%20vice-versa%3B%20the%20order%20is%20not%20documented%29.%20For%20%60git%20clone%60%2C%20all%20user-facing%20output%20goes%20to%20stderr%2C%20so%20this%20accidentally%20gives%20you%20the%20right%20content%20on%20failure%2C%20but%20the%20stdout%20capture%20is%20silently%20discarded.%20If%20the%20ordering%20ever%20differs%20across%20CMake%20versions%2C%20the%20%60FATAL_ERROR%60%20message%20would%20surface%20empty%20stdout%20instead%20of%20the%20clone%20error.%20Using%20distinct%20variables%20and%20concatenating%20in%20the%20error%20message%20is%20explicit%20and%20future-proof.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20execute_process%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20COMMAND%20%22%24%7BGIT_EXECUTABLE%7D%22%20clone%20--depth%201%20--no-tags%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20--branch%20v6.26.0%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20https%3A%2F%2Finvent.kde.org%2Fframeworks%2Fextra-cmake-modules.git%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%24%7B_ecm_src%7D%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20OUTPUT_VARIABLE%20_ecm_clone_out%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20ERROR_VARIABLE%20_ecm_clone_err%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20RESULT_VARIABLE%20_ecm_clone%29%0A%20%20%20%20%20%20%20%20%20%20%20%20if%28NOT%20_ecm_clone%20EQUAL%200%29%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20message%28FATAL_ERROR%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22ECM%20clone%20failed%20%28exit%20%24%7B_ecm_clone%7D%29%3A%5Cn%24%7B_ecm_clone_out%7D%24%7B_ecm_clone_err%7D%22%29%0A%60%60%60%0A%0A&repo=gesslar%2Fmdv.qt&pr=22&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["review: address Greptile findings on PR ..."](https://github.com/gesslar/mdv.qt/commit/c9bbdaf34d9a23db6435ecb50858eee2ae76e2f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34284961)</sub>

<!-- /greptile_comment -->