### PR TITLE
pre-fetch QWindowKit in flatpak manifest for offline sandbox build

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -136,8 +136,8 @@ the link line if you add a library. RPM `Requires:` are auto-detected by
 
 A single-file `.flatpak` is built with `flatpak-builder` against the KDE runtime
 (`org.kde.Platform` 6.9), which already ships Qt 6 and KSyntaxHighlighting — so
-only md4c is built alongside mdv. The manifest `dev.gesslar.mdv.yml` builds
-straight from this checkout (no pushed tag required).
+the only externals built alongside mdv are md4c and QWindowKit. The manifest
+`dev.gesslar.mdv.yml` builds straight from this checkout (no pushed tag required).
 
 ```bash
 make flatpak   # → dist/mdv-<version>-<arch>.flatpak
@@ -160,6 +160,26 @@ flatpak run dev.gesslar.mdv                 # run/install are by app-id, not fil
 
 For a Flathub submission, repoint the `mdv` module source from this local
 checkout to a pinned remote (url + tag + commit).
+
+> **Why QWindowKit needs special handling in the manifest.** mdv pulls
+> QWindowKit via CMake `FetchContent`, which clones from GitHub *at configure
+> time*. That's fine for the `.deb`/`.rpm`/`.AppImage` builds, but
+> flatpak-builder runs its build in a **network-isolated sandbox** — the clone
+> dies with `Could not resolve host: github.com`. So the manifest pre-fetches
+> QWindowKit as a `git` source during flatpak-builder's network-enabled
+> download phase (submodules included — QWindowKit carries `qmsetup`) and points
+> `FETCHCONTENT_SOURCE_DIR_QWINDOWKIT` at that checkout so the in-sandbox
+> configure skips the clone.
+>
+> A second, subtler wrinkle: QWindowKit configure-time-builds `qmsetup` into a
+> private tree, then `find_package`s it back from
+> `<prefix>/${CMAKE_INSTALL_LIBDIR}`. flatpak-builder forces
+> `CMAKE_INSTALL_LIBDIR=lib` on the module, but that qmsetup sub-build is a
+> separate `cmake` run flatpak-builder doesn't touch — on the (non-Debian) KDE
+> SDK its GNUInstallDirs defaults to `lib64`, so the lookup misses under `lib`.
+> The manifest pins the module to `lib64` so both halves agree (harmless: mdv
+> installs only to `bin/` and `share/`, never libdir). Full detail lives in the
+> comments in `dev.gesslar.mdv.yml`.
 
 ### AppImage
 

--- a/dev.gesslar.mdv.yml
+++ b/dev.gesslar.mdv.yml
@@ -3,8 +3,10 @@
 #
 # Self-contained: the `mdv` module builds straight from THIS repo's working tree
 # (type: dir, path: .) — no presumed pushed tag or sibling directory. The KDE
-# runtime already ships Qt 6 and KSyntaxHighlighting (KF6), so the only thing we
-# build alongside mdv is md4c, the one genuinely-external dependency.
+# runtime already ships Qt 6 and KSyntaxHighlighting (KF6), so the external
+# sources we supply alongside mdv are md4c (its own module below) and QWindowKit
+# (pre-fetched on the mdv module — see the note there), since the in-sandbox
+# build has no network to fetch them itself.
 #
 # For a Flathub submission, swap the mdv source to a pinned remote
 # (type: git with url + tag + commit) — Flathub builds from a published ref,
@@ -91,6 +93,25 @@ modules:
     buildsystem: cmake-ninja
     config-opts:
       - -DCMAKE_BUILD_TYPE=Release
+      # QWindowKit (frameless-window scaffolding) is FetchContent'd by our
+      # CMakeLists at configure time. flatpak-builder runs the build in a
+      # network-isolated sandbox, so that clone fails with "Could not resolve
+      # host: github.com". Instead we pre-fetch QWindowKit as a source below
+      # (downloaded — with its qmsetup submodule — during flatpak-builder's
+      # network-enabled download phase) and point FetchContent at that checkout
+      # so it skips the clone. /run/build/<module-name> is flatpak-builder's
+      # fixed in-sandbox build dir, so this absolute path is stable; its final
+      # component must match the source's `dest` below.
+      - -DFETCHCONTENT_SOURCE_DIR_QWINDOWKIT=/run/build/mdv/qwindowkit
+      # QWindowKit configure-time-builds its qmsetup dependency into a private
+      # tree, then find_package()s it back from <prefix>/${CMAKE_INSTALL_LIBDIR}.
+      # flatpak-builder forces CMAKE_INSTALL_LIBDIR=lib on this module, but that
+      # qmsetup sub-build is a separate cmake run flatpak-builder doesn't touch,
+      # so its GNUInstallDirs picks the non-debian 64-bit default (lib64) and
+      # installs there — the find_package then misses under lib. Pin the module
+      # to lib64 so both halves agree. Harmless: mdv installs only to bin/ and
+      # share/ (never libdir), so nothing else moves.
+      - -DCMAKE_INSTALL_LIBDIR=lib64
     sources:
       - type: dir
         path: .
@@ -103,3 +124,14 @@ modules:
           - build-release
           - dist
           - .flatpak-builder
+      # QWindowKit, pre-fetched for the offline in-sandbox build (see the
+      # FETCHCONTENT_SOURCE_DIR_QWINDOWKIT config-opt above). flatpak-builder
+      # clones this — and its qmsetup submodule, whose relative URL resolves
+      # against this repo — while it still has network. Pinned by tag + commit
+      # like md4c. `dest` lands it at /run/build/mdv/qwindowkit, matching the
+      # config-opt path.
+      - type: git
+        url: https://github.com/stdware/qwindowkit.git
+        tag: 1.5.0
+        commit: 35e88f3655720ed0537c7dd1dde243bf4a70c94c
+        dest: qwindowkit


### PR DESCRIPTION
Adds QWindowKit as a pre-fetched source in the Flatpak manifest to work around the network-isolated sandbox environment used by flatpak-builder.

Since mdv pulls QWindowKit via CMake `FetchContent` at configure time, the in-sandbox build would fail trying to clone from GitHub. The manifest now downloads QWindowKit (including its `qmsetup` submodule) during flatpak-builder's network-enabled download phase and points `FETCHCONTENT_SOURCE_DIR_QWINDOWKIT` at that checkout so the configure step skips the clone entirely.

Also pins `CMAKE_INSTALL_LIBDIR=lib64` on the mdv module to resolve a mismatch between the lib directory flatpak-builder forces on the module and the `lib64` default that QWindowKit's internal `qmsetup` sub-build uses when installing, which would otherwise cause the subsequent `find_package` to fail.

`DEVELOPMENT.md` is updated to document both of these Flatpak-specific wrinkles and explain why they are necessary.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pre-fetches QWindowKit (tag `1.5.0`, commit `35e88f3`) as a Flatpak manifest source so the in-sandbox build can skip the `FetchContent` network clone, and pins `CMAKE_INSTALL_LIBDIR=lib64` to align the qmsetup sub-build's install prefix with what the main configure expects. `DEVELOPMENT.md` is updated to document both workarounds.

- Adds a `type: git` source for QWindowKit under `dest: qwindowkit`; `FETCHCONTENT_SOURCE_DIR_QWINDOWKIT` is set to `/run/build/mdv/qwindowkit`, which is the correct stable in-sandbox path that flatpak-builder writes sources to.
- Pins `CMAKE_INSTALL_LIBDIR=lib64` on the `mdv` module with a detailed inline comment explaining the mismatch between the top-level module override and the separate `cmake` run QWindowKit uses for its qmsetup sub-build.
- Both the tag/commit pin and the submodule handling are correct: the 1.5.0 commit matches the published GitHub tag, and flatpak-builder fetches submodules by default, so `qmsetup` will be present without an explicit `submodules: true`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are confined to the Flatpak manifest and its documentation, with no effect on other build paths.

The QWindowKit tag-to-commit pin was verified against the published GitHub release (matches). Submodule handling is correct by flatpak-builder's default behaviour. The FETCHCONTENT path and lib64 alignment are well-reasoned and the inline comments prove the author understood the constraint. No logic errors or build-breaking issues were found in the changed files.

No files require special attention.

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `dev.gesslar.mdv.yml`, line 34-38 ([link](https://github.com/gesslar/mdv.qt/blob/9f035e50662c3f4cee0bdddb2d2dfa79a7fdcf13/dev.gesslar.mdv.yml#L34-L38)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Because `CMAKE_INSTALL_LIBDIR=lib64` is now pinned, qmsetup (and potentially QWindowKit itself) will install cmake-config files to `/app/lib64/cmake` and pkg-config files to `/app/lib64/pkgconfig`. The global `cleanup` only strips `/lib/cmake` and `/lib/pkgconfig` (matching `/app/lib/…`), so those build-time artifacts will survive into the final bundle. Adding the `lib64` variants keeps the bundle lean.

   

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20dev.gesslar.mdv.yml%0ALine%3A%2034-38%0A%0AComment%3A%0ABecause%20%60CMAKE_INSTALL_LIBDIR%3Dlib64%60%20is%20now%20pinned%2C%20qmsetup%20%28and%20potentially%20QWindowKit%20itself%29%20will%20install%20cmake-config%20files%20to%20%60%2Fapp%2Flib64%2Fcmake%60%20and%20pkg-config%20files%20to%20%60%2Fapp%2Flib64%2Fpkgconfig%60.%20The%20global%20%60cleanup%60%20only%20strips%20%60%2Flib%2Fcmake%60%20and%20%60%2Flib%2Fpkgconfig%60%20%28matching%20%60%2Fapp%2Flib%2F%E2%80%A6%60%29%2C%20so%20those%20build-time%20artifacts%20will%20survive%20into%20the%20final%20bundle.%20Adding%20the%20%60lib64%60%20variants%20keeps%20the%20bundle%20lean.%0A%0A%60%60%60suggestion%0Acleanup%3A%0A%20%20-%20%2Finclude%0A%20%20-%20%2Flib%2Fpkgconfig%0A%20%20-%20%2Flib%2Fcmake%0A%20%20-%20%2Flib64%2Fpkgconfig%0A%20%20-%20%2Flib64%2Fcmake%0A%20%20-%20'*.a'%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gesslar%2Fmdv.qt&pr=23&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fixes"](https://github.com/gesslar/mdv.qt/commit/b55d14933eea532f6b82bea24a1f161e0e2ec4e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34287577)</sub>

<!-- /greptile_comment -->