### PR TITLE
add VSCode launch, tasks, and settings; unignore .vscode/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ compile_commands.json
 CMakeLists.txt.user*
 
 # IDE
-.vscode/
 .idea/
 .vs/
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,8 @@
         "miDebuggerPath": "/usr/bin/gdb"
       },
       "osx": {
-        "MIMode": "lldb"
+        "MIMode": "lldb",
+        "miDebuggerPath": "/usr/bin/lldb"
       },
       "windows": {
         "program": "${workspaceFolder}/build/mdv.exe",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug mdv",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceFolder}/build/mdv",
+      "args": [],
+      "stopAtEntry": false,
+      "cwd": "${workspaceFolder}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "preLaunchTask": "build (debug)",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ],
+      "linux": {
+        "miDebuggerPath": "/usr/bin/gdb"
+      },
+      "osx": {
+        "MIMode": "lldb"
+      },
+      "windows": {
+        "program": "${workspaceFolder}/build/mdv.exe",
+        "miDebuggerPath": "gdb.exe"
+      }
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+  // IntelliSense resolves Qt + KSyntaxHighlighting headers from the compile DB
+  // that `make build` writes (CMAKE_EXPORT_COMPILE_COMMANDS=ON).
+  "C_Cpp.default.compileCommands": "${workspaceFolder}/build/compile_commands.json",
+
+  // The Makefile owns build/ (CMake + Ninja). Don't let CMake Tools auto-
+  // configure and race it — build / run / format / lint all go through the make
+  // tasks (Terminal > Run Task, or Ctrl+Shift+B for the default build).
+  "cmake.configureOnOpen": false,
+
+  // Keep build output out of quick-open / search and off the file watcher.
+  "search.exclude": {
+    "build": true,
+    "build-release": true,
+    "dist": true
+  },
+  "files.watcherExclude": {
+    "**/build/**": true,
+    "**/build-release/**": true,
+    "**/dist/**": true
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,46 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build (debug)",
+      "type": "shell",
+      "command": "make build",
+      "options": { "cwd": "${workspaceFolder}" },
+      "group": { "kind": "build", "isDefault": true },
+      "problemMatcher": ["$gcc"],
+      "detail": "cmake -B build (Debug) + ninja"
+    },
+    {
+      "label": "run",
+      "type": "shell",
+      "command": "make run",
+      "options": { "cwd": "${workspaceFolder}" },
+      "problemMatcher": ["$gcc"],
+      "detail": "build the dev binary, then launch build/mdv"
+    },
+    {
+      "label": "release",
+      "type": "shell",
+      "command": "make release",
+      "options": { "cwd": "${workspaceFolder}" },
+      "problemMatcher": ["$gcc"],
+      "detail": "optimized build into build-release/"
+    },
+    {
+      "label": "format",
+      "type": "shell",
+      "command": "make format",
+      "options": { "cwd": "${workspaceFolder}" },
+      "problemMatcher": [],
+      "detail": "clang-format -i over src/ (the formatting source of truth)"
+    },
+    {
+      "label": "lint",
+      "type": "shell",
+      "command": "make lint",
+      "options": { "cwd": "${workspaceFolder}" },
+      "problemMatcher": ["$gcc"],
+      "detail": "format-check + clang-tidy + clazy"
+    }
+  ]
+}


### PR DESCRIPTION
Add VS Code workspace configuration for building, debugging, and linting

Commits `.vscode/` to the repository and removes it from `.gitignore` so the configuration is shared across contributors.

- **`launch.json`** – Adds a `Debug mdv` launch configuration that runs a pre-launch debug build via GDB on Linux/Windows and LLDB on macOS.
- **`settings.json`** – Points IntelliSense at the CMake-generated `compile_commands.json`, disables CMake Tools auto-configure (the `Makefile` owns the build directory), and excludes `build/`, `build-release/`, and `dist/` from search and file watching.
- **`tasks.json`** – Exposes `build (debug)`, `run`, `release`, `format`, and `lint` as VS Code tasks, all delegating to the corresponding `make` targets. `build (debug)` is set as the default build task (`Ctrl+Shift+B`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR commits `.vscode/` workspace configuration to the repository and removes it from `.gitignore` so the setup is shared across contributors. It adds a `launch.json` for cross-platform GDB/LLDB debugging, a `settings.json` that wires IntelliSense to the CMake compile database and disables CMake Tools auto-configure, and a `tasks.json` that exposes `build`, `run`, `release`, `format`, and `lint` as VS Code tasks delegating to `make` targets.

- **`launch.json`** configures a `Debug mdv` launch profile with per-platform debugger overrides (GDB on Linux/Windows, LLDB on macOS), with `build (debug)` as the pre-launch task.
- **`settings.json`** excludes `build/`, `build-release/`, and `dist/` from both search and file watching, and prevents CMake Tools from racing the Makefile-owned build directory.
- **`tasks.json`** registers five shell tasks mapped to `make` targets, with `build (debug)` set as the default `Ctrl+Shift+B` build task.

<h3>Confidence Score: 5/5</h3>

This PR only adds VS Code workspace configuration files with no changes to source code, build logic, or runtime behavior — it is safe to merge.

All changes are purely IDE configuration (.vscode/ JSON files and a .gitignore edit). No source code, CMake targets, CI workflows, or runtime logic is touched, so there is no risk of introducing regressions.

No files require special attention.

<sub>Reviews (6): Last reviewed commit: ["Apply suggestion from @greptile-apps\[bot..."](https://github.com/gesslar/mdv.qt/commit/82183e2ca40f7eafdc1677e5c14460410e1cea11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34289367)</sub>

<!-- /greptile_comment -->