### PR TITLE
bump to 2.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(mdv
-    VERSION 2.0.2
+    VERSION 2.1.0
     DESCRIPTION "An offline Markdown viewer for everybody! For free! Huzzah!"
     LANGUAGES CXX
 )


### PR DESCRIPTION
Bump version to 2.1.0

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the project version from `2.0.2` to `2.1.0` in `CMakeLists.txt`.

- Single-line change updating the `VERSION` field in the `project()` declaration from `2.0.2` to `2.1.0`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-field version bump with no functional impact.

Only the VERSION field in CMakeLists.txt is touched; no build logic, source files, or dependencies are affected.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["bump"](https://github.com/gesslar/mdv.qt/commit/d7f06d4085d93823770a7fa9493da3c165509c4b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34293271)</sub>

<!-- /greptile_comment -->