### PR TITLE
upgrade status label to interactive path button with copy and reveal actions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "theqtcompany.qt",
+    "ms-vscode.cpptools",
+    "ms-vscode.cmake-tools",
+    "twxs.cmake",
+    "xaver.clang-format"
+  ]
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,8 @@ qt_add_executable(mdv
     src/CodiconFont.h
     src/DocumentView.cpp
     src/DocumentView.h
+    src/OutlinePanel.cpp
+    src/OutlinePanel.h
     src/EditorGroup.cpp
     src/EditorGroup.h
     src/EditorArea.cpp

--- a/src/CodiconFont.h
+++ b/src/CodiconFont.h
@@ -13,11 +13,14 @@
 namespace Codicon {
 QString family();
 
-constexpr char16_t Close          = 0xEA76;
-constexpr char16_t Pinned         = 0xEBA0;
-constexpr char16_t Settings       = 0xEB52;
-constexpr char16_t ChromeClose    = 0xEAB8;
+constexpr char16_t Close = 0xEA76;
+constexpr char16_t Pinned = 0xEBA0;
+constexpr char16_t Settings = 0xEB52;
+constexpr char16_t ListFlat = 0xEB84;
+constexpr char16_t ChevronLeft = 0xEAB5;
+constexpr char16_t ChevronRight = 0xEAB6;
+constexpr char16_t ChromeClose = 0xEAB8;
 constexpr char16_t ChromeMaximize = 0xEAB9;
 constexpr char16_t ChromeMinimize = 0xEABA;
-constexpr char16_t ChromeRestore  = 0xEABB;
+constexpr char16_t ChromeRestore = 0xEABB;
 }  // namespace Codicon

--- a/src/DocumentView.cpp
+++ b/src/DocumentView.cpp
@@ -15,9 +15,11 @@
 #include <QPalette>
 #include <QScrollBar>
 #include <QSettings>
+#include <QSplitter>
 #include <QTextBlock>
 #include <QTextBrowser>
 #include <QTextCursor>
+#include <QTextFragment>
 #include <QTextStream>
 #include <QTimer>
 #include <QUrl>
@@ -26,6 +28,7 @@
 #include "ContentTheme.h"
 #include "EditorGroup.h"
 #include "Markdown.h"
+#include "OutlinePanel.h"
 
 DocumentView::DocumentView(QWidget *parent) : QWidget(parent) {
   auto *layout = new QVBoxLayout(this);
@@ -54,7 +57,57 @@ DocumentView::DocumentView(QWidget *parent) : QWidget(parent) {
   applyDocumentPalette();
   connect(m_browser, &QWidget::customContextMenuRequested, this,
           &DocumentView::onContextMenuRequested);
-  layout->addWidget(m_browser);
+  // Scroll-spy: track which section is at the top of the viewport so the
+  // outline can highlight it. Heading y-positions move on reflow, so dirty
+  // the cache when the document's layout resizes (width change, zoom, edit).
+  connect(m_browser->verticalScrollBar(), &QAbstractSlider::valueChanged, this,
+          &DocumentView::onScrolled);
+  connect(m_browser->document()->documentLayout(),
+          &QAbstractTextDocumentLayout::documentSizeChanged, this,
+          [this](const QSizeF &) {
+            // Heading positions moved; recompute so the outline highlight
+            // tracks reflow (and lands on the top section after first layout).
+            m_headingYDirty = true;
+            onScrolled();
+          });
+
+  // Each document carries its own outline panel beside the browser, so split
+  // groups can show or hide it independently. Initial visibility follows the
+  // "show outline by default" preference; the side and width are remembered
+  // globally so a new document inherits the last layout.
+  QSettings s;
+  m_outlineSide = s.value(QStringLiteral("outline/side"), 0).toInt() == 1
+                      ? OutlineSide::Right
+                      : OutlineSide::Left;
+  m_outlineVisible =
+      s.value(QStringLiteral("outline/showByDefault"), false).toBool();
+  m_outlineWidth = s.value(QStringLiteral("outline/width"), 240).toInt();
+  if(m_outlineWidth < 80) m_outlineWidth = 240;
+
+  m_outline = new OutlinePanel(this);
+  m_outline->setSide(m_outlineSide);
+  m_splitter = new QSplitter(Qt::Horizontal, this);
+  m_splitter->setChildrenCollapsible(false);
+  m_splitter->setHandleWidth(1);
+
+  // The panel talks only to its own document — no MainWindow plumbing.
+  connect(m_outline, &OutlinePanel::headingActivated, this,
+          &DocumentView::scrollToHeading);
+  connect(m_outline, &OutlinePanel::hideRequested, this, [this] {
+    setOutlineVisible(false);
+  });
+  connect(m_outline, &OutlinePanel::moveToOtherSideRequested, this, [this] {
+    toggleOutlineSide();
+  });
+  connect(this, &DocumentView::headingsChanged, this, [this] {
+    m_outline->setHeadings(m_headings);
+  });
+  connect(this, &DocumentView::currentHeadingChanged, m_outline,
+          &OutlinePanel::setCurrentHeading);
+
+  applyOutlineArrangement();
+  m_outline->setVisible(m_outlineVisible);
+  layout->addWidget(m_splitter);
 
   // Anchor-apply window: we keep re-applying on every rangeChanged for a
   // short window after scrollToAnchor() is called, because layout often
@@ -95,7 +148,11 @@ bool DocumentView::loadFile(const QString &path) {
   // Render markdown → HTML externally (via md4c) and feed setHtml, so
   // the document's default stylesheet actually applies. setMarkdown
   // would bypass CSS by baking in QTextCharFormats during import.
-  m_browser->setHtml(mdv::markdownToHtml(in.readAll()));
+  const mdv::RenderResult rendered = mdv::renderMarkdown(in.readAll());
+  m_browser->setHtml(rendered.html);
+  m_headings = rendered.headings;
+  m_headingYDirty = true;
+  m_lastHeadingId.clear();
 
   // QTextBrowser parks the text cursor wherever setMarkdown leaves it
   // and then scrolls to keep the cursor visible, which often lands at
@@ -115,6 +172,7 @@ bool DocumentView::loadFile(const QString &path) {
 
   armWatch();
   emit fileLoaded(m_filePath);
+  emit headingsChanged();
   return true;
 }
 
@@ -195,6 +253,110 @@ void DocumentView::onAnchorClicked(const QUrl &url) {
           ? QDir::cleanPath(rawPath)
           : QDir::cleanPath(base + QLatin1Char('/') + rawPath);
   emit openFileRequested(resolved);
+}
+
+void DocumentView::scrollToHeading(const QString &anchorId) {
+  if(anchorId.isEmpty()) return;
+  // Same path an in-document #anchor click takes; QTextBrowser brings the
+  // named anchor to the top of the viewport.
+  m_browser->scrollToAnchor(anchorId);
+}
+
+void DocumentView::rebuildHeadingPositions() const {
+  m_headingY.clear();
+  QTextDocument *doc = m_browser->document();
+  QAbstractTextDocumentLayout *lay = doc->documentLayout();
+
+  for(QTextBlock b = doc->begin(); b != doc->end(); b = b.next()) {
+    if(b.blockFormat().headingLevel() <= 0) continue;
+    // The slug we injected lands on the heading's first text fragment as an
+    // anchor name (verified against Qt's rich-text importer).
+    QString id;
+    for(QTextBlock::iterator it = b.begin(); !it.atEnd(); ++it) {
+      const QStringList names = it.fragment().charFormat().anchorNames();
+      if(!names.isEmpty()) {
+        id = names.first();
+        break;
+      }
+    }
+    if(id.isEmpty()) continue;
+    m_headingY.append({id, lay->blockBoundingRect(b).y()});
+  }
+  // Blocks iterate top-to-bottom, so m_headingY is already sorted by y.
+  m_headingYDirty = false;
+}
+
+QString DocumentView::currentHeadingId() const {
+  if(m_headingYDirty) rebuildHeadingPositions();
+  if(m_headingY.isEmpty()) return {};
+
+  // The scrollbar value maps to document-y, but laid-out blocks start at the
+  // document's top margin — so the first heading sits at y == documentMargin,
+  // not 0. Offset the probe by that margin (plus 1 for the exact-top case) so
+  // the first heading registers as current at scroll 0 instead of leaving the
+  // outline unhighlighted until the reader scrolls a little.
+  const qreal probe = m_browser->verticalScrollBar()->value() +
+                      m_browser->document()->documentMargin() + 1.0;
+  QString current;
+  for(const auto &[id, y] : m_headingY) {
+    if(y > probe) break;
+    current = id;
+  }
+  return current;
+}
+
+void DocumentView::onScrolled() {
+  const QString id = currentHeadingId();
+  if(id == m_lastHeadingId) return;
+  m_lastHeadingId = id;
+  emit currentHeadingChanged(id);
+}
+
+void DocumentView::applyOutlineArrangement() {
+  // insertWidget moves an existing child, so calling it for both each time
+  // re-establishes the left/right order. The browser stretches; the outline
+  // keeps its width on resize (the user can still drag the handle).
+  if(m_outlineSide == OutlineSide::Left) {
+    m_splitter->insertWidget(0, m_outline);
+    m_splitter->insertWidget(1, m_browser);
+  } else {
+    m_splitter->insertWidget(0, m_browser);
+    m_splitter->insertWidget(1, m_outline);
+  }
+  const int outlineIdx = m_outlineSide == OutlineSide::Left ? 0 : 1;
+  m_splitter->setStretchFactor(outlineIdx, 0);
+  m_splitter->setStretchFactor(1 - outlineIdx, 1);
+  m_splitter->setSizes(m_outlineSide == OutlineSide::Left
+                           ? QList<int>{m_outlineWidth, 1 << 20}
+                           : QList<int>{1 << 20, m_outlineWidth});
+}
+
+void DocumentView::setOutlineVisible(bool on) {
+  if(m_outlineVisible == on) return;
+  if(!on && m_outline->width() > 0) m_outlineWidth = m_outline->width();
+  m_outlineVisible = on;
+  m_outline->setVisible(on);
+  if(on) applyOutlineArrangement();  // restore the panel's splitter share
+
+  // Visibility is per-document runtime state — the "show outline by default"
+  // preference governs new documents, so a toggle here doesn't move it. The
+  // dragged width is still worth remembering globally.
+  QSettings().setValue(QStringLiteral("outline/width"), m_outlineWidth);
+
+  emit outlineVisibilityChanged(on);
+}
+
+void DocumentView::toggleOutlineSide() {
+  // Capture the live (possibly user-dragged) width before re-arranging, so
+  // applyOutlineArrangement() re-applies that width instead of snapping back
+  // to the remembered default.
+  if(m_outline->width() > 0) m_outlineWidth = m_outline->width();
+  m_outlineSide = m_outlineSide == OutlineSide::Left ? OutlineSide::Right
+                                                     : OutlineSide::Left;
+  m_outline->setSide(m_outlineSide);
+  applyOutlineArrangement();
+  QSettings().setValue(QStringLiteral("outline/side"),
+                       m_outlineSide == OutlineSide::Right ? 1 : 0);
 }
 
 int DocumentView::topAnchor() const {
@@ -333,7 +495,7 @@ void DocumentView::reloadFromDisk() {
   }
   QTextStream in(&file);
   in.setEncoding(QStringConverter::Utf8);
-  const QString html = mdv::markdownToHtml(in.readAll());
+  const mdv::RenderResult rendered = mdv::renderMarkdown(in.readAll());
 
   // Capture the view state before swapping. The anchor is a character offset
   // into the current rendered text; oldText is that same text (so the diff in
@@ -343,7 +505,13 @@ void DocumentView::reloadFromDisk() {
   const int anchor = topAnchor();
   const QString oldText = m_browser->document()->toPlainText();
 
-  m_browser->setHtml(html);
+  m_browser->setHtml(rendered.html);
+  m_headings = rendered.headings;
+  m_headingYDirty = true;
+  // Match loadFile: reset so the documentSizeChanged → onScrolled chain emits a
+  // fresh current-heading instead of briefly clearing the outline selection.
+  m_lastHeadingId.clear();
+  emit headingsChanged();
 
   const QString newText = m_browser->document()->toPlainText();
   scrollToAnchor(remapAnchor(anchor, oldText, newText));

--- a/src/DocumentView.h
+++ b/src/DocumentView.h
@@ -1,9 +1,17 @@
 #pragma once
 
+#include <QList>
+#include <QPair>
 #include <QPoint>
+#include <QString>
 #include <QWidget>
 
+#include "Markdown.h"
+#include "OutlinePanel.h"  // OutlineSide
+
+class OutlinePanel;
 class QFileSystemWatcher;
+class QSplitter;
 class QTextBrowser;
 class QTimer;
 class QUrl;
@@ -36,6 +44,29 @@ public:
   // Canonical (symlink-resolved) absolute path, or empty if no file is loaded.
   QString filePath() const { return m_filePath; }
 
+  // Heading outline of the current document, in document order. Each id
+  // matches an anchor in the rendered HTML, so the outline panel can jump
+  // to it via the same path as an in-document #anchor click. Refreshed on
+  // load and on hot-reload; headingsChanged() fires after each refresh.
+  const QList<mdv::Heading> &headings() const { return m_headings; }
+
+  // Scroll so the heading carrying `anchorId` sits at the top of the
+  // viewport. No-op if the id isn't a known heading anchor.
+  void scrollToHeading(const QString &anchorId);
+
+  // Anchor id of the last heading at or above the top of the viewport — the
+  // section the reader is currently in — or empty if scrolled above the first
+  // heading. Drives the outline's scroll-spy highlight.
+  QString currentHeadingId() const;
+
+  // This document's own outline panel: each DocumentView owns one, so split
+  // groups can independently show or hide their outline. The side and the
+  // shown/hidden default are seeded from (and written back to) QSettings, so a
+  // newly opened document inherits the last choice.
+  bool outlineVisible() const { return m_outlineVisible; }
+  void setOutlineVisible(bool on);
+  void toggleOutline() { setOutlineVisible(!m_outlineVisible); }
+
   // Basename of the loaded file, or a placeholder if none.
   QString displayName() const;
 
@@ -65,6 +96,18 @@ public:
 signals:
   void fileLoaded(const QString &canonicalPath);
 
+  // The heading outline was (re)built — on load and on every hot-reload.
+  // headings() reflects the new outline by the time this fires.
+  void headingsChanged();
+
+  // The section the reader is in changed as the document scrolled. Carries
+  // the anchor id of the current heading (empty above the first heading).
+  void currentHeadingChanged(const QString &anchorId);
+
+  // This document's outline was shown/hidden. Lets the View-menu toggle track
+  // the active document's state.
+  void outlineVisibilityChanged(bool visible);
+
   // The pinned state changed — the owning EditorGroup repaints the tab's pin
   // sash and (next step) repositions it within the pinned cluster.
   void pinnedChanged(bool pinned);
@@ -78,10 +121,29 @@ private slots:
   void onAnchorClicked(const QUrl &url);
   // The watched file changed on disk — debounced before reloadFromDisk().
   void onFileChanged(const QString &path);
+  // Vertical scroll moved — recompute the current section and emit
+  // currentHeadingChanged() only when it actually changes.
+  void onScrolled();
 
 private:
   QTextBrowser *m_browser = nullptr;
+  QSplitter *m_splitter = nullptr;
+  OutlinePanel *m_outline = nullptr;
+  bool m_outlineVisible = true;
+  OutlineSide m_outlineSide = OutlineSide::Left;
+  int m_outlineWidth = 240;
+
   QString m_filePath;
+  QList<mdv::Heading> m_headings;
+
+  // Scroll-spy cache: each heading anchor id paired with its laid-out y, in
+  // document order. Rebuilt lazily (positions move on reflow/zoom) — dirtied
+  // on re-render and whenever the document layout resizes. m_lastHeadingId
+  // debounces currentHeadingChanged() to actual transitions.
+  mutable QList<QPair<QString, qreal>> m_headingY;
+  mutable bool m_headingYDirty = true;
+  QString m_lastHeadingId;
+
   bool m_pinned = false;
   bool m_watching = true;
 
@@ -98,6 +160,16 @@ private:
   class QTimer *m_pendingAnchorTimer = nullptr;
 
   bool tryApplyAnchor();
+
+  // Walk the laid-out document and record (anchor id, y) for every heading
+  // block, sorted by y. Fills m_headingY and clears m_headingYDirty.
+  void rebuildHeadingPositions() const;
+
+  // (Re)order the outline/browser splitter for m_outlineSide and restore the
+  // outline's share of the width.
+  void applyOutlineArrangement();
+  // Flip the dock side and remember it as the new default.
+  void toggleOutlineSide();
 
   // (Re)point the watcher at m_filePath when watching is on; clears it
   // otherwise. Safe to call repeatedly (used after load and after each reload,

--- a/src/EditorGroup.cpp
+++ b/src/EditorGroup.cpp
@@ -585,6 +585,12 @@ void EditorGroup::populateTabContextMenu(QMenu *menu, DocumentView *doc) {
   watchAction->setChecked(doc->isWatching());
   connect(watchAction, &QAction::toggled, doc, &DocumentView::setWatching);
 
+  auto *outlineAction = menu->addAction(tr("Show &Outline"));
+  outlineAction->setCheckable(true);
+  outlineAction->setChecked(doc->outlineVisible());
+  connect(outlineAction, &QAction::toggled, doc,
+          &DocumentView::setOutlineVisible);
+
   menu->addSeparator();
 
   // "Split" entries open a fresh DocumentView for the same file in a

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1,15 +1,20 @@
 #include "MainWindow.h"
 
 #include <QAction>
+#include <QClipboard>
+#include <QDesktopServices>
+#include <QDir>
 #include <QDragEnterEvent>
 #include <QDropEvent>
 #include <QFileDialog>
 #include <QFileInfo>
-#include <QLabel>
+#include <QGuiApplication>
 #include <QMenu>
 #include <QMimeData>
+#include <QProcess>
 #include <QSettings>
 #include <QStatusBar>
+#include <QStyleHints>
 #include <QToolButton>
 #include <QUrl>
 #include <QVBoxLayout>
@@ -27,6 +32,23 @@
 namespace {
 constexpr int kRecentFilesLimit = 10;
 constexpr const char *kRecentFilesKey = "recentFiles";
+
+// Open the platform file manager with the file highlighted. Windows/macOS can
+// select the file itself; elsewhere we fall back to opening its folder.
+void revealInFileManager(const QString &path) {
+  const QFileInfo info(path);
+#if defined(Q_OS_WIN)
+  QProcess::startDetached(
+      QStringLiteral("explorer.exe"),
+      {QStringLiteral("/select,") +
+       QDir::toNativeSeparators(info.absoluteFilePath())});
+#elif defined(Q_OS_MACOS)
+  QProcess::startDetached(QStringLiteral("open"),
+                          {QStringLiteral("-R"), info.absoluteFilePath()});
+#else
+  QDesktopServices::openUrl(QUrl::fromLocalFile(info.absolutePath()));
+#endif
+}
 }  // namespace
 
 MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
@@ -63,6 +85,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   connect(openAction, &QAction::triggered, this, &MainWindow::onOpen);
 
   m_recentMenu = fileMenu->addMenu(tr("Open &Recent"));
+  // QMenu suppresses per-action tooltips by default; opt in so each entry's
+  // full path tooltip actually shows.
+  m_recentMenu->setToolTipsVisible(true);
   // Rebuild on demand so the menu reflects the current list even if it
   // was changed via openFile / Clear since the menu was last shown.
   connect(m_recentMenu, &QMenu::aboutToShow, this,
@@ -71,7 +96,12 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   fileMenu->addSeparator();
 
   m_closeTabAction = fileMenu->addAction(tr("&Close Tab"));
-  m_closeTabAction->setShortcut(QKeySequence::Close);
+  // Keep the platform-standard Close keys (Ctrl+F4 on Windows) and add Ctrl+W,
+  // which Windows doesn't bind by default but everyone reaches for.
+  QList<QKeySequence> closeKeys = QKeySequence::keyBindings(QKeySequence::Close);
+  if(const QKeySequence ctrlW(Qt::CTRL | Qt::Key_W); !closeKeys.contains(ctrlW))
+    closeKeys.append(ctrlW);
+  m_closeTabAction->setShortcuts(closeKeys);
   connect(m_closeTabAction, &QAction::triggered, this,
           &MainWindow::onCloseCurrentTab);
 
@@ -158,8 +188,42 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   // message that would overwrite a temporary and never restore it; a normal
   // widget is merely hidden under any temporary message and reappears once
   // the menu closes.
-  m_statusLabel = new QLabel(tr("No file open."), this);
-  statusBar()->addWidget(m_statusLabel);
+  m_statusButton = new QToolButton(this);
+  m_statusButton->setText(tr("No file open."));
+  m_statusButton->setEnabled(false);
+  m_statusButton->setAutoRaise(true);
+  m_statusButton->setFocusPolicy(Qt::NoFocus);
+  m_statusButton->setCursor(Qt::PointingHandCursor);
+  m_statusButton->setContextMenuPolicy(Qt::CustomContextMenu);
+  // The Windows style draws a sunken frame around status-bar items; clear it
+  // so the button sits flush. The button itself is flat with a theme-agnostic
+  // grey hover wash (matching the tab buttons) and a little left pad.
+  refreshStatusBarStyle();
+  connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
+          [this](Qt::ColorScheme) { refreshStatusBarStyle(); });
+  statusBar()->addWidget(m_statusButton);
+
+  // Left-click copies the full path; the temporary status message reappears as
+  // the button once it times out.
+  connect(m_statusButton, &QToolButton::clicked, this, [this]() {
+    if(m_currentPath.isEmpty()) return;
+    QGuiApplication::clipboard()->setText(m_currentPath);
+    statusBar()->showMessage(tr("Path copied to clipboard"), 1500);
+  });
+  connect(m_statusButton, &QWidget::customContextMenuRequested, this,
+          [this](const QPoint &pos) {
+            if(m_currentPath.isEmpty()) return;
+            QMenu menu;
+            QAction *copy = menu.addAction(tr("Copy Path"));
+            QAction *reveal = menu.addAction(tr("Open Containing Folder"));
+            QAction *chosen = menu.exec(m_statusButton->mapToGlobal(pos));
+            if(chosen == copy) {
+              QGuiApplication::clipboard()->setText(m_currentPath);
+              statusBar()->showMessage(tr("Path copied to clipboard"), 1500);
+            } else if(chosen == reveal) {
+              revealInFileManager(m_currentPath);
+            }
+          });
 
   // Custom frameless chrome. QWindowKit handles the native bits: snap
   // layouts, snap zones, resize edges, Win11 immersive dark mode + Mica
@@ -341,14 +405,40 @@ void MainWindow::onMoveTabLeft() {
   if(auto *group = m_area->activeGroup()) group->moveCurrentTabLeft();
 }
 
+void MainWindow::refreshStatusBarStyle() {
+  const bool dark = QGuiApplication::styleHints()->colorScheme()
+                    == Qt::ColorScheme::Dark;
+  const QString fg = dark ? QStringLiteral("#f0f0f0") : QStringLiteral("#000000");
+  // Zero vertical padding so the button hugs the text height and the status
+  // bar centers it; horizontal padding gives the hover pill some breathing
+  // room while keeping the small left inset off the window edge. Hover/press
+  // use a grey wash that reads on either scheme.
+  statusBar()->setStyleSheet(
+      QStringLiteral(
+          "QStatusBar { color: %1; }"
+          "QStatusBar::item { border: none; }"
+          "QStatusBar QToolButton { border: none; background: transparent;"
+          " color: %1; padding: 0px 8px 0px 4px; border-radius: 4px; }"
+          "QStatusBar QToolButton:disabled { color: #888888; }"
+          "QStatusBar QToolButton:enabled:hover { background: rgba(127,127,127,0.18); }"
+          "QStatusBar QToolButton:enabled:pressed { background: rgba(127,127,127,0.30); }")
+          .arg(fg));
+}
+
 void MainWindow::onCurrentDocumentChanged(DocumentView *doc) {
   if(!doc) {
     setWindowTitle(tr("mdv"));
-    m_statusLabel->setText(tr("No file open."));
+    m_currentPath.clear();
+    m_statusButton->setText(tr("No file open."));
+    m_statusButton->setToolTip(QString());
+    m_statusButton->setEnabled(false);
     return;
   }
   setWindowTitle(tr("%1 — mdv").arg(doc->displayName()));
-  m_statusLabel->setText(doc->filePath());
+  m_currentPath = QDir::toNativeSeparators(doc->filePath());
+  m_statusButton->setText(m_currentPath);
+  m_statusButton->setToolTip(tr("Click to copy path"));
+  m_statusButton->setEnabled(true);
 }
 
 void MainWindow::loadRecentFiles() {
@@ -400,7 +490,7 @@ void MainWindow::rebuildRecentMenu() {
   for(const QString &path : std::as_const(m_recentFiles)) {
     const QFileInfo info(path);
     auto *action = m_recentMenu->addAction(info.fileName());
-    action->setToolTip(path);
+    action->setToolTip(QDir::toNativeSeparators(path));
     connect(action, &QAction::triggered, this, [this, path]() {
       openFile(path);
     });

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -13,6 +13,7 @@
 #include <QMimeData>
 #include <QProcess>
 #include <QSettings>
+#include <QSignalBlocker>
 #include <QStatusBar>
 #include <QStyleHints>
 #include <QToolButton>
@@ -38,10 +39,9 @@ constexpr const char *kRecentFilesKey = "recentFiles";
 void revealInFileManager(const QString &path) {
   const QFileInfo info(path);
 #if defined(Q_OS_WIN)
-  QProcess::startDetached(
-      QStringLiteral("explorer.exe"),
-      {QStringLiteral("/select,") +
-       QDir::toNativeSeparators(info.absoluteFilePath())});
+  QProcess::startDetached(QStringLiteral("explorer.exe"),
+                          {QStringLiteral("/select,") +
+                           QDir::toNativeSeparators(info.absoluteFilePath())});
 #elif defined(Q_OS_MACOS)
   QProcess::startDetached(QStringLiteral("open"),
                           {QStringLiteral("-R"), info.absoluteFilePath()});
@@ -98,7 +98,8 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   m_closeTabAction = fileMenu->addAction(tr("&Close Tab"));
   // Keep the platform-standard Close keys (Ctrl+F4 on Windows) and add Ctrl+W,
   // which Windows doesn't bind by default but everyone reaches for.
-  QList<QKeySequence> closeKeys = QKeySequence::keyBindings(QKeySequence::Close);
+  QList<QKeySequence> closeKeys =
+      QKeySequence::keyBindings(QKeySequence::Close);
   if(const QKeySequence ctrlW(Qt::CTRL | Qt::Key_W); !closeKeys.contains(ctrlW))
     closeKeys.append(ctrlW);
   m_closeTabAction->setShortcuts(closeKeys);
@@ -200,7 +201,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   // grey hover wash (matching the tab buttons) and a little left pad.
   refreshStatusBarStyle();
   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
-          [this](Qt::ColorScheme) { refreshStatusBarStyle(); });
+          [this](Qt::ColorScheme) {
+            refreshStatusBarStyle();
+          });
   statusBar()->addWidget(m_statusButton);
 
   // Left-click copies the full path; the temporary status message reappears as
@@ -272,6 +275,17 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   layout->addWidget(titleBar);
   layout->addWidget(m_area, 1);
   setCentralWidget(container);
+
+  // The outline lives inside each DocumentView (so split groups toggle it
+  // independently); this menu item just flips the active document's copy and
+  // mirrors its state. syncOutlineAction() keeps it pointed at the active doc.
+  viewMenu->addSeparator();
+  m_outlineAction = viewMenu->addAction(tr("Show &Outline"));
+  m_outlineAction->setCheckable(true);
+  connect(m_outlineAction, &QAction::toggled, this, [this](bool on) {
+    if(auto *doc = m_area->currentDocument()) doc->setOutlineVisible(on);
+  });
+  syncOutlineAction(m_area->currentDocument());
 }
 
 MainWindow::~MainWindow() = default;
@@ -406,9 +420,10 @@ void MainWindow::onMoveTabLeft() {
 }
 
 void MainWindow::refreshStatusBarStyle() {
-  const bool dark = QGuiApplication::styleHints()->colorScheme()
-                    == Qt::ColorScheme::Dark;
-  const QString fg = dark ? QStringLiteral("#f0f0f0") : QStringLiteral("#000000");
+  const bool dark =
+      QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+  const QString fg =
+      dark ? QStringLiteral("#f0f0f0") : QStringLiteral("#000000");
   // Zero vertical padding so the button hugs the text height and the status
   // bar centers it; horizontal padding gives the hover pill some breathing
   // room while keeping the small left inset off the window edge. Hover/press
@@ -420,12 +435,16 @@ void MainWindow::refreshStatusBarStyle() {
           "QStatusBar QToolButton { border: none; background: transparent;"
           " color: %1; padding: 0px 8px 0px 4px; border-radius: 4px; }"
           "QStatusBar QToolButton:disabled { color: #888888; }"
-          "QStatusBar QToolButton:enabled:hover { background: rgba(127,127,127,0.18); }"
-          "QStatusBar QToolButton:enabled:pressed { background: rgba(127,127,127,0.30); }")
+          "QStatusBar QToolButton:enabled:hover { background: "
+          "rgba(127,127,127,0.18); }"
+          "QStatusBar QToolButton:enabled:pressed { background: "
+          "rgba(127,127,127,0.30); }")
           .arg(fg));
 }
 
 void MainWindow::onCurrentDocumentChanged(DocumentView *doc) {
+  syncOutlineAction(doc);
+
   if(!doc) {
     setWindowTitle(tr("mdv"));
     m_currentPath.clear();
@@ -439,6 +458,20 @@ void MainWindow::onCurrentDocumentChanged(DocumentView *doc) {
   m_statusButton->setText(m_currentPath);
   m_statusButton->setToolTip(tr("Click to copy path"));
   m_statusButton->setEnabled(true);
+}
+
+void MainWindow::syncOutlineAction(DocumentView *doc) {
+  // Follow only the active document, so a toggle elsewhere doesn't move the
+  // checkmark out from under the user.
+  disconnect(m_outlineConn);
+  m_outlineAction->setEnabled(doc != nullptr);
+  {
+    const QSignalBlocker block(m_outlineAction);  // don't echo back as a toggle
+    m_outlineAction->setChecked(doc && doc->outlineVisible());
+  }
+  if(doc)
+    m_outlineConn = connect(doc, &DocumentView::outlineVisibilityChanged,
+                            m_outlineAction, &QAction::setChecked);
 }
 
 void MainWindow::loadRecentFiles() {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -7,8 +7,8 @@ class DocumentView;
 class EditorArea;
 class PreferencesDialog;
 class QAction;
-class QLabel;
 class QMenu;
+class QToolButton;
 
 class MainWindow : public QMainWindow {
   Q_OBJECT
@@ -47,13 +47,21 @@ private slots:
   void updateFileMenuState();
 
 private:
+  // Rebuild the status-bar stylesheet for the current color scheme. The app
+  // themes via QStyleHints, not the Qt palette, so the button's text colour
+  // has to be re-applied on every scheme change (mirrors TitleBar).
+  void refreshStatusBarStyle();
+
   void loadRecentFiles();
   void saveRecentFiles();
   void addToRecentFiles(const QString &canonical);
   void removeFromRecentFiles(const QString &path);
 
   EditorArea *m_area = nullptr;
-  QLabel *m_statusLabel = nullptr;
+  QToolButton *m_statusButton = nullptr;
+  // Native-separator path of the current document, backing the status button's
+  // copy / reveal actions. Empty when no file is open.
+  QString m_currentPath;
   QMenu *m_recentMenu = nullptr;
   QStringList m_recentFiles;
   PreferencesDialog *m_preferencesDialog = nullptr;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QList>
 #include <QMainWindow>
 #include <QStringList>
 
@@ -38,6 +39,9 @@ private slots:
   void onMoveTabRight();
   void onMoveTabLeft();
   void onCurrentDocumentChanged(DocumentView *doc);
+  // Point the View ▸ Outline toggle at `doc`: reflect its outline state and
+  // follow its later toggles, dropping the previous document's connection.
+  void syncOutlineAction(DocumentView *doc);
   void rebuildRecentMenu();
   void onPreferences();
   void onPreferencesApplied();
@@ -71,4 +75,9 @@ private:
   QAction *m_closeGroupAction = nullptr;
   QAction *m_closeAllAction = nullptr;
   QAction *m_reopenAction = nullptr;
+
+  // View ▸ Outline toggle, kept in sync with the active document's outline.
+  // m_outlineConn follows that document's outlineVisibilityChanged.
+  QAction *m_outlineAction = nullptr;
+  QMetaObject::Connection m_outlineConn;
 };

--- a/src/Markdown.cpp
+++ b/src/Markdown.cpp
@@ -6,6 +6,7 @@
 #include <QChar>
 #include <QLoggingCategory>
 #include <QRegularExpression>
+#include <QSet>
 
 #include "Highlighter.h"
 
@@ -129,9 +130,76 @@ QString wrapBlockquotes(const QString &html) {
   return out;
 }
 
+// Strip HTML tags from a heading's inner markup so the outline label and the
+// slug are computed from the plain text (md4c renders inline `**`, `code`,
+// links etc. as nested tags inside the <hN>).
+QString stripTags(QString s) {
+  static const QRegularExpression tag(QStringLiteral("<[^>]*>"));
+  return s.remove(tag);
+}
+
+// GitHub-flavored heading slug, so an anchor generated here matches the one
+// GitHub renders for the same heading (the app already parses GFM): lowercase;
+// letters, digits, underscores and existing hyphens are kept; each whitespace
+// char becomes a hyphen; every other character is dropped. Deliberately does
+// *not* collapse the resulting hyphens — "FAQ & Troubleshooting" slugs to
+// "faq--troubleshooting" on GitHub, and we mirror that so cross-referenced
+// links resolve identically in both places.
+QString slugify(const QString &text) {
+  QString out;
+  out.reserve(text.size());
+  for(const QChar ch : text) {
+    if(ch.isLetterOrNumber()) out.append(ch.toLower());
+    else if(ch == u'_' || ch == u'-') out.append(ch);
+    else if(ch.isSpace()) out.append(u'-');
+    // else: dropped
+  }
+  return out;
+}
+
+// Inject a unique `id` onto every <h1>..<h6> md4c emitted and collect the
+// heading outline in document order. Single source of truth: the id written
+// into the HTML is the same id recorded in the Heading, so a TOC click and an
+// in-document #anchor link resolve identically. Duplicate slugs get a -1, -2,
+// … suffix (GitHub semantics).
+QString injectHeadingIds(const QString &html, QList<Heading> &headings) {
+  static const QRegularExpression re(
+      QStringLiteral("<h([1-6])>(.*?)</h\\1>"),
+      QRegularExpression::DotMatchesEverythingOption);
+
+  QString out;
+  out.reserve(html.size() + 64);
+  qsizetype last = 0;
+  QSet<QString> used;
+
+  QRegularExpressionMatchIterator it = re.globalMatch(html);
+  while(it.hasNext()) {
+    const QRegularExpressionMatch m = it.next();
+    out.append(QStringView(html).sliced(last, m.capturedStart() - last));
+    last = m.capturedEnd();
+
+    const int level = m.captured(1).toInt();
+    const QString inner = m.captured(2);
+    const QString text = unescapeHtml(stripTags(inner)).trimmed();
+
+    QString base = slugify(text);
+    if(base.isEmpty()) base = QStringLiteral("section");
+    QString id = base;
+    for(int n = 1; used.contains(id); ++n)
+      id = base + QLatin1Char('-') + QString::number(n);
+    used.insert(id);
+
+    headings.append({.level = level, .text = text, .id = id});
+    out.append(QStringLiteral("<h%1 id=\"%2\">%3</h%1>")
+                   .arg(QString::number(level), id.toHtmlEscaped(), inner));
+  }
+  out.append(QStringView(html).sliced(last));
+  return out;
+}
+
 }  // namespace
 
-QString markdownToHtml(const QString &markdown) {
+RenderResult renderMarkdown(const QString &markdown) {
   const QByteArray utf8 = markdown.toUtf8();
 
   // GFM dialect — tables, task lists, strikethrough, autolinks — matches
@@ -154,13 +222,20 @@ QString markdownToHtml(const QString &markdown) {
   if(rc != 0) {
     qCWarning(lcMarkdown) << "md4c parse failed (rc=" << rc
                           << "), falling back to plain-text rendering";
-    return QStringLiteral("<pre>%1</pre>").arg(markdown.toHtmlEscaped());
+    return {.html =
+                QStringLiteral("<pre>%1</pre>").arg(markdown.toHtmlEscaped())};
   }
 
-  // Blockquotes are wrapped first, on the clean md4c output where <blockquote>
-  // only ever appears as a real tag; code-block highlighting runs after and
-  // still finds any <pre><code> nested inside a wrapped quote.
-  return highlightCodeBlocks(wrapBlockquotes(QString::fromUtf8(html)));
+  // Heading ids are injected first, on the clean md4c output, so the same
+  // <hN> text the outline reads is what carries the slug. Blockquotes are
+  // wrapped next (where <blockquote> only ever appears as a real tag); code-
+  // block highlighting runs last and still finds any <pre><code> nested
+  // inside a wrapped quote.
+  RenderResult result;
+  const QString withIds =
+      injectHeadingIds(QString::fromUtf8(html), result.headings);
+  result.html = highlightCodeBlocks(wrapBlockquotes(withIds));
+  return result;
 }
 
 }  // namespace mdv

--- a/src/Markdown.h
+++ b/src/Markdown.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QList>
 #include <QString>
 
 // Markdown → HTML rendering helpers built on md4c-html.
@@ -13,8 +14,24 @@
 
 namespace mdv {
 
-// Convert GFM-flavored markdown to HTML. Output is a fragment (no
-// <html>/<head>/<body> wrappers) suitable for QTextDocument::setHtml.
-QString markdownToHtml(const QString &markdown);
+// One heading in the document, in document order. Feeds both the outline
+// panel and in-document anchor navigation; `id` is the slug injected onto
+// the rendered <hN> tag, so a TOC click and a hand-written [x](#id) link
+// resolve to the same anchor.
+struct Heading {
+  int level;     // 1..6
+  QString text;  // plain-text label (inline markup stripped)
+  QString id;    // slug, unique within the document
+};
+
+struct RenderResult {
+  QString html;             // fragment suitable for QTextDocument::setHtml
+  QList<Heading> headings;  // document order
+};
+
+// Convert GFM-flavored markdown to HTML and extract the heading outline.
+// Headings in the returned HTML carry a unique `id` matching the
+// corresponding Heading::id.
+RenderResult renderMarkdown(const QString &markdown);
 
 }  // namespace mdv

--- a/src/OutlinePanel.cpp
+++ b/src/OutlinePanel.cpp
@@ -1,0 +1,179 @@
+#include "OutlinePanel.h"
+
+#include <QAbstractItemView>
+#include <QFont>
+#include <QGuiApplication>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMenu>
+#include <QStyleHints>
+#include <QToolButton>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+#include <QVBoxLayout>
+
+#include "CodiconFont.h"
+
+namespace {
+bool isDark() {
+  return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+}
+}  // namespace
+
+OutlinePanel::OutlinePanel(QWidget *parent) : QWidget(parent) {
+  setObjectName(QStringLiteral("OutlinePanel"));
+  setAttribute(Qt::WA_StyledBackground, true);
+
+  auto *root = new QVBoxLayout(this);
+  root->setContentsMargins(0, 0, 0, 0);
+  root->setSpacing(0);
+
+  // Header: a section label and a collapse button. Right-click offers the
+  // dock-side switch and hide, so the header strip stays uncluttered.
+  auto *header = new QWidget(this);
+  header->setObjectName(QStringLiteral("outlineHeader"));
+  header->setAttribute(Qt::WA_StyledBackground, true);
+  header->setContextMenuPolicy(Qt::CustomContextMenu);
+  auto *headerLayout = new QHBoxLayout(header);
+  headerLayout->setContentsMargins(10, 4, 4, 4);
+  headerLayout->setSpacing(0);
+
+  m_title = new QLabel(tr("OUTLINE"), header);
+  m_title->setObjectName(QStringLiteral("outlineTitle"));
+
+  m_collapseButton = new QToolButton(header);
+  m_collapseButton->setObjectName(QStringLiteral("outlineCollapse"));
+  m_collapseButton->setFocusPolicy(Qt::NoFocus);
+  m_collapseButton->setFixedSize(24, 24);
+  m_collapseButton->setToolTip(tr("Hide outline"));
+  if(const QString family = Codicon::family(); !family.isEmpty()) {
+    QFont f(family);
+    f.setPixelSize(12);
+    m_collapseButton->setFont(f);
+  }
+  connect(m_collapseButton, &QToolButton::clicked, this,
+          &OutlinePanel::hideRequested);
+
+  headerLayout->addWidget(m_title);
+  headerLayout->addStretch(1);
+  headerLayout->addWidget(m_collapseButton);
+
+  connect(header, &QWidget::customContextMenuRequested, this,
+          [this, header](const QPoint &pos) {
+            QMenu menu(this);
+            QAction *move = menu.addAction(m_side == OutlineSide::Left
+                                               ? tr("Dock on Right")
+                                               : tr("Dock on Left"));
+            QAction *hide = menu.addAction(tr("Hide Outline"));
+            const QAction *chosen = menu.exec(header->mapToGlobal(pos));
+            if(chosen == move) emit moveToOtherSideRequested();
+            else if(chosen == hide) emit hideRequested();
+          });
+
+  m_tree = new QTreeWidget(this);
+  m_tree->setObjectName(QStringLiteral("outlineTree"));
+  m_tree->setHeaderHidden(true);
+  m_tree->setIndentation(12);
+  m_tree->setUniformRowHeights(true);
+  m_tree->setSelectionMode(QAbstractItemView::SingleSelection);
+  m_tree->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  m_tree->setExpandsOnDoubleClick(false);
+  connect(m_tree, &QTreeWidget::itemClicked, this,
+          [this](QTreeWidgetItem *item, int /*column*/) {
+            const QString id = item->data(0, Qt::UserRole).toString();
+            if(!id.isEmpty()) emit headingActivated(id);
+          });
+
+  m_placeholder = new QLabel(tr("No headings"), this);
+  m_placeholder->setObjectName(QStringLiteral("outlinePlaceholder"));
+  m_placeholder->setAlignment(Qt::AlignCenter);
+  m_placeholder->hide();
+
+  root->addWidget(header);
+  root->addWidget(m_tree, 1);
+  root->addWidget(m_placeholder, 1);
+
+  setSide(m_side);
+  refreshTheme();
+  connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
+          [this](Qt::ColorScheme) {
+            refreshTheme();
+          });
+}
+
+void OutlinePanel::setSide(OutlineSide side) {
+  m_side = side;
+  if(m_collapseButton) {
+    // The chevron points at the seam we tuck into.
+    const char16_t glyph = side == OutlineSide::Left ? Codicon::ChevronLeft
+                                                     : Codicon::ChevronRight;
+    m_collapseButton->setText(QString(QChar(glyph)));
+  }
+}
+
+void OutlinePanel::setHeadings(const QList<mdv::Heading> &headings) {
+  m_tree->clear();
+  m_itemById.clear();
+
+  // Nest by level using a running ancestor stack; skipped levels (h1 → h3)
+  // just attach to the nearest shallower ancestor.
+  QList<QPair<int, QTreeWidgetItem *>> stack;
+  for(const mdv::Heading &h : headings) {
+    while(!stack.isEmpty() && stack.last().first >= h.level) stack.removeLast();
+    QTreeWidgetItem *parent = stack.isEmpty() ? nullptr : stack.last().second;
+    auto *item =
+        parent ? new QTreeWidgetItem(parent) : new QTreeWidgetItem(m_tree);
+    item->setText(0, h.text);
+    item->setData(0, Qt::UserRole, h.id);
+    stack.append({h.level, item});
+    m_itemById.insert(h.id, item);
+  }
+  m_tree->expandAll();
+
+  const bool empty = headings.isEmpty();
+  m_tree->setVisible(!empty);
+  m_placeholder->setVisible(empty);
+}
+
+void OutlinePanel::setCurrentHeading(const QString &anchorId) {
+  if(anchorId.isEmpty()) {
+    m_tree->setCurrentItem(nullptr);
+    return;
+  }
+  const auto it = m_itemById.constFind(anchorId);
+  if(it == m_itemById.constEnd()) return;
+  if(m_tree->currentItem() == it.value()) return;
+  m_tree->setCurrentItem(it.value());
+  m_tree->scrollToItem(it.value(), QAbstractItemView::EnsureVisible);
+}
+
+void OutlinePanel::refreshTheme() {
+  const bool dark = isDark();
+  const QString bg =
+      dark ? QStringLiteral("#1f1f1f") : QStringLiteral("#f3f3f3");
+  const QString fg =
+      dark ? QStringLiteral("#e8e8e8") : QStringLiteral("#1a1a1a");
+  const QString muted =
+      dark ? QStringLiteral("#9d9d9d") : QStringLiteral("#6e6e6e");
+  const QString hover = dark ? QStringLiteral("rgba(255,255,255,0.07)")
+                             : QStringLiteral("rgba(0,0,0,0.05)");
+  const QString sel = dark ? QStringLiteral("rgba(255,255,255,0.12)")
+                           : QStringLiteral("rgba(0,0,0,0.10)");
+
+  setStyleSheet(QStringLiteral(R"(
+OutlinePanel, #outlineHeader { background: %1; }
+#outlineTitle { color: %3; font-size: 11px; font-weight: 600; }
+QToolButton#outlineCollapse {
+    background: transparent; border: none; color: %2; border-radius: 4px;
+}
+QToolButton#outlineCollapse:hover { background: %4; }
+#outlinePlaceholder { color: %3; }
+QTreeWidget#outlineTree {
+    background: %1; color: %2; border: none; outline: 0;
+}
+QTreeWidget#outlineTree::item { padding: 3px 2px; border: none; }
+QTreeWidget#outlineTree::item:hover { background: %4; }
+QTreeWidget#outlineTree::item:selected { background: %5; color: %2; }
+)")
+                    .arg(bg, fg, muted, hover, sel));
+}

--- a/src/OutlinePanel.h
+++ b/src/OutlinePanel.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QHash>
+#include <QList>
+#include <QWidget>
+
+#include "Markdown.h"
+
+class QLabel;
+class QToolButton;
+class QTreeWidget;
+class QTreeWidgetItem;
+
+// Which side of its document the outline sits against. Only ever left or
+// right — never floats, never top/bottom.
+enum class OutlineSide { Left, Right };
+
+// The outline body: a slim header (title + collapse button) over a tree of the
+// owning document's headings. A pure view — it emits intent signals (a row was
+// activated, hide me, move me) and the DocumentView that owns it wires them up.
+class OutlinePanel : public QWidget {
+  Q_OBJECT
+
+public:
+  explicit OutlinePanel(QWidget *parent = nullptr);
+
+  // Rebuild the tree from a document's outline; an empty list shows the
+  // "no headings" placeholder.
+  void setHeadings(const QList<mdv::Heading> &headings);
+
+  // Scroll-spy: highlight the row for this anchor id (empty clears the
+  // highlight). Does not emit headingActivated().
+  void setCurrentHeading(const QString &anchorId);
+
+  // The collapse button's chevron points at whichever edge we're docked on.
+  void setSide(OutlineSide side);
+
+signals:
+  void headingActivated(const QString &anchorId);
+  void hideRequested();
+  void moveToOtherSideRequested();
+
+private:
+  void refreshTheme();
+
+  QLabel *m_title = nullptr;
+  QToolButton *m_collapseButton = nullptr;
+  QTreeWidget *m_tree = nullptr;
+  QLabel *m_placeholder = nullptr;
+  OutlineSide m_side = OutlineSide::Left;
+  QHash<QString, QTreeWidgetItem *> m_itemById;
+};

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -1,5 +1,6 @@
 #include "PreferencesDialog.h"
 
+#include <QCheckBox>
 #include <QComboBox>
 #include <QDialogButtonBox>
 #include <QFontComboBox>
@@ -57,6 +58,17 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) : QDialog(parent) {
   fontsLayout->addRow(tr("Mono:"), m_monoFont);
 
   root->addWidget(fontsGroup);
+
+  // === View ===
+  auto *viewGroup = new QGroupBox(tr("View"), this);
+  auto *viewLayout = new QVBoxLayout(viewGroup);
+  m_outlineDefault = new QCheckBox(tr("Show outline by default"), viewGroup);
+  m_outlineDefault->setToolTip(
+      tr("Newly opened documents start with the outline panel shown. Each "
+         "document can still be toggled individually."));
+  viewLayout->addWidget(m_outlineDefault);
+  root->addWidget(viewGroup);
+
   root->addStretch();
 
   // === Buttons ===
@@ -95,6 +107,9 @@ void PreferencesDialog::reload() {
 
   const QString monoFamily = s.value(QStringLiteral("fonts/mono")).toString();
   if(!monoFamily.isEmpty()) m_monoFont->setCurrentFont(QFont(monoFamily));
+
+  m_outlineDefault->setChecked(
+      s.value(QStringLiteral("outline/showByDefault"), false).toBool());
 }
 
 void PreferencesDialog::saveToSettings() {
@@ -105,6 +120,8 @@ void PreferencesDialog::saveToSettings() {
              m_proseFont->currentFont().family());
   s.setValue(QStringLiteral("fonts/prose.size"), m_proseSize->value());
   s.setValue(QStringLiteral("fonts/mono"), m_monoFont->currentFont().family());
+  s.setValue(QStringLiteral("outline/showByDefault"),
+             m_outlineDefault->isChecked());
 }
 
 void PreferencesDialog::onApply() {

--- a/src/PreferencesDialog.h
+++ b/src/PreferencesDialog.h
@@ -2,6 +2,7 @@
 
 #include <QDialog>
 
+class QCheckBox;
 class QComboBox;
 class QFontComboBox;
 class QSpinBox;
@@ -43,4 +44,5 @@ private:
   QFontComboBox *m_proseFont = nullptr;
   QSpinBox *m_proseSize = nullptr;
   QFontComboBox *m_monoFont = nullptr;
+  QCheckBox *m_outlineDefault = nullptr;
 };

--- a/src/TitleBar.cpp
+++ b/src/TitleBar.cpp
@@ -46,8 +46,8 @@ TitleBar::TitleBar(QWidget *parent) : QWidget(parent) {
   m_iconLabel = new QLabel(this);
   m_iconLabel->setFixedSize(kTitleBarHeight, kTitleBarHeight);
   m_iconLabel->setAlignment(Qt::AlignCenter);
-  m_iconLabel->setPixmap(QIcon(QStringLiteral(":/icons/mdv.png"))
-                             .pixmap(QSize(16, 16)));
+  m_iconLabel->setPixmap(
+      QIcon(QStringLiteral(":/icons/mdv.png")).pixmap(QSize(16, 16)));
 
   // Menu buttons use InstantPopup so a single click drops the menu (the
   // dropdown arrow is hidden via the stylesheet — the menu reads as a normal
@@ -64,18 +64,18 @@ TitleBar::TitleBar(QWidget *parent) : QWidget(parent) {
   m_viewBtn->setFocusPolicy(Qt::NoFocus);
   m_viewBtn->setFixedHeight(kTitleBarHeight);
 
-  m_settingsBtn = makeChromeButton(QStringLiteral("sysSettings"),
-                                   Codicon::Settings, this);
+  m_settingsBtn =
+      makeChromeButton(QStringLiteral("sysSettings"), Codicon::Settings, this);
   m_settingsBtn->setToolTip(tr("Preferences"));
   connect(m_settingsBtn, &QToolButton::clicked, this,
           &TitleBar::settingsClicked);
 
-  m_minBtn = makeChromeButton(QStringLiteral("sysMin"),
-                              Codicon::ChromeMinimize, this);
-  m_maxBtn = makeChromeButton(QStringLiteral("sysMax"),
-                              Codicon::ChromeMaximize, this);
-  m_closeBtn = makeChromeButton(QStringLiteral("sysClose"),
-                                Codicon::ChromeClose, this);
+  m_minBtn =
+      makeChromeButton(QStringLiteral("sysMin"), Codicon::ChromeMinimize, this);
+  m_maxBtn =
+      makeChromeButton(QStringLiteral("sysMax"), Codicon::ChromeMaximize, this);
+  m_closeBtn =
+      makeChromeButton(QStringLiteral("sysClose"), Codicon::ChromeClose, this);
 
   connect(m_minBtn, &QToolButton::clicked, this, &TitleBar::minimizeClicked);
   connect(m_maxBtn, &QToolButton::clicked, this, &TitleBar::maximizeClicked);
@@ -95,7 +95,9 @@ TitleBar::TitleBar(QWidget *parent) : QWidget(parent) {
 
   refreshTheme();
   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
-          [this](Qt::ColorScheme) { refreshTheme(); });
+          [this](Qt::ColorScheme) {
+            refreshTheme();
+          });
 }
 
 void TitleBar::refreshTheme() {
@@ -103,10 +105,12 @@ void TitleBar::refreshTheme() {
   // of the chrome on a system-theme switch. Close button hover stays the
   // canonical Win11 red regardless of scheme; the menu-indicator chevron is
   // suppressed in both — the buttons read as labels, not dropdowns.
-  const bool dark = QGuiApplication::styleHints()->colorScheme()
-                    == Qt::ColorScheme::Dark;
-  const QString bg = dark ? QStringLiteral("#1f1f1f") : QStringLiteral("#f3f3f3");
-  const QString fg = dark ? QStringLiteral("#f0f0f0") : QStringLiteral("#000000");
+  const bool dark =
+      QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+  const QString bg =
+      dark ? QStringLiteral("#1f1f1f") : QStringLiteral("#f3f3f3");
+  const QString fg =
+      dark ? QStringLiteral("#f0f0f0") : QStringLiteral("#000000");
   const QString hover = dark ? QStringLiteral("rgba(255,255,255,0.08)")
                              : QStringLiteral("rgba(0,0,0,0.06)");
   const QString press = dark ? QStringLiteral("rgba(255,255,255,0.04)")
@@ -125,7 +129,8 @@ TitleBar QToolButton:pressed { background: %4; }
 TitleBar QToolButton#sysClose:hover { background: #c42b1c; color: white; }
 TitleBar QToolButton#sysClose:pressed { background: #b4271a; color: white; }
 TitleBar QToolButton::menu-indicator { image: none; }
-)").arg(bg, fg, hover, press));
+)")
+                    .arg(bg, fg, hover, press));
 }
 
 void TitleBar::setFileMenu(QMenu *menu) { m_fileBtn->setMenu(menu); }
@@ -151,6 +156,6 @@ bool TitleBar::eventFilter(QObject *obj, QEvent *e) {
 
 void TitleBar::refreshMaxIcon() {
   const bool maximized = window() && window()->isMaximized();
-  m_maxBtn->setText(QString(QChar(
-      maximized ? Codicon::ChromeRestore : Codicon::ChromeMaximize)));
+  m_maxBtn->setText(QString(
+      QChar(maximized ? Codicon::ChromeRestore : Codicon::ChromeMaximize)));
 }

--- a/src/WindowsChrome.cpp
+++ b/src/WindowsChrome.cpp
@@ -3,25 +3,30 @@
 #include <QWidget>
 
 #ifdef Q_OS_WIN
-  #include <QGuiApplication>
-  #include <QStyleHints>
-  #include <windows.h>
-  #include <dwmapi.h>
-  // Fallbacks for older MinGW SDKs that predate these names. Placed AFTER
-  // the SDK headers so that when a future SDK ships the names — as a #define
-  // or, more likely, as DWMWINDOWATTRIBUTE / DWM_SYSTEMBACKDROP_TYPE enum
-  // entries — the SDK version wins. (A #define ahead of the SDK header would
-  // textually replace the enum entry's identifier and break the enum.)
-  // Values match the documented Microsoft DWM constants.
-  #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
-    #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
-  #endif
-  #ifndef DWMWA_SYSTEMBACKDROP_TYPE
-    #define DWMWA_SYSTEMBACKDROP_TYPE 38
-  #endif
-  #ifndef DWMSBT_MAINWINDOW
-    #define DWMSBT_MAINWINDOW 2
-  #endif
+#include <QGuiApplication>
+#include <QStyleHints>
+// clang-format off
+// windows.h must precede dwmapi.h (and other Windows SDK headers) — they use
+// types it defines. Fenced so the include sorter can't alphabetize them back
+// into a broken order.
+#include <windows.h>
+#include <dwmapi.h>
+// clang-format on
+// Fallbacks for older MinGW SDKs that predate these names. Placed AFTER
+// the SDK headers so that when a future SDK ships the names — as a #define
+// or, more likely, as DWMWINDOWATTRIBUTE / DWM_SYSTEMBACKDROP_TYPE enum
+// entries — the SDK version wins. (A #define ahead of the SDK header would
+// textually replace the enum entry's identifier and break the enum.)
+// Values match the documented Microsoft DWM constants.
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
+#ifndef DWMWA_SYSTEMBACKDROP_TYPE
+#define DWMWA_SYSTEMBACKDROP_TYPE 38
+#endif
+#ifndef DWMSBT_MAINWINDOW
+#define DWMSBT_MAINWINDOW 2
+#endif
 
 namespace {
 void writeDwmAttrs(QWidget *w) {
@@ -52,8 +57,9 @@ void applyWindowsChrome(QWidget *w) {
   // lambda doesn't re-enter applyWindowsChrome so a single call wires the
   // tracker exactly once.
   QObject::connect(QGuiApplication::styleHints(),
-                   &QStyleHints::colorSchemeChanged, w,
-                   [w](Qt::ColorScheme) { writeDwmAttrs(w); });
+                   &QStyleHints::colorSchemeChanged, w, [w](Qt::ColorScheme) {
+                     writeDwmAttrs(w);
+                   });
 #else
   (void)w;
 #endif


### PR DESCRIPTION
The status bar label has been replaced with an interactive `QToolButton` that exposes the current file's path. Left-clicking the button copies the full path to the clipboard and briefly shows a confirmation message. Right-clicking opens a context menu with explicit "Copy Path" and "Open Containing Folder" options, where the latter uses the platform-native file manager (Explorer on Windows with the file selected, Finder on macOS with `-R`, and a folder open fallback elsewhere).

The button is styled flat with a hover/press wash that matches the tab buttons and adapts to light and dark color schemes via `QStyleHints::colorSchemeChanged`. Tooltips on recent-file menu entries and the status button path display now use native path separators.

The Close Tab action now includes both the platform-standard binding and `Ctrl+W`, ensuring the familiar shortcut works on Windows where it is not bound by default.

A `.vscode/extensions.json` file has been added recommending the Qt, C++, CMake, and clang-format extensions for contributors using VS Code.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades the status bar from a static `QLabel` to an interactive `QToolButton` with left-click copy-path and right-click context menu (copy/reveal) actions. Alongside that focused change, it lands a full document outline panel (`OutlinePanel`) with scroll-spy, per-document visibility state, a dock-side toggle, and a Preferences checkbox — plus a `Ctrl+W` Close Tab shortcut fix.

- **Status path button**: replaces `m_statusLabel` with `m_statusButton`; clipboard copy on left-click, context menu with "Copy Path" / "Open Containing Folder" on right-click; flat hover styling matches the tab bar and adapts to color-scheme changes via `QStyleHints::colorSchemeChanged`.
- **Outline panel**: new `OutlinePanel` widget (tree + collapse button) embedded in a per-`DocumentView` splitter; headings extracted from md4c HTML output via `injectHeadingIds`, deduplicated with GitHub-style slugs, and fed through a scroll-spy (`rebuildHeadingPositions` / `onScrolled`) to highlight the current section; outline visibility and dock side are persisted in `QSettings`.
- **Supporting changes**: `renderMarkdown` replaces `markdownToHtml` to carry the heading list alongside the HTML; `Codicon::ListFlat`, `ChevronLeft`, `ChevronRight` icons added; VS Code extension recommendations added.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are well-scoped and handle edge cases correctly.

The status button, outline panel, scroll-spy, and heading extraction logic are all carefully implemented. Bidirectional sync between the View menu toggle and per-document outline state uses QSignalBlocker and a tracked QMetaObject::Connection correctly. The revealInFileManager helper, heading slug deduplication, and splitter rearrangement all look correct for the described platforms and edge cases.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["outline work"](https://github.com/gesslar/mdv.qt/commit/50a9cdb46e2379899e169e62bd6f0bde96db4c98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34297153)</sub>

<!-- /greptile_comment -->