### PR TITLE
add document outline panel with scroll-spy and per-document toggle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,8 @@ qt_add_executable(mdv
     src/CodiconFont.h
     src/DocumentView.cpp
     src/DocumentView.h
+    src/OutlinePanel.cpp
+    src/OutlinePanel.h
     src/EditorGroup.cpp
     src/EditorGroup.h
     src/EditorArea.cpp

--- a/src/CodiconFont.h
+++ b/src/CodiconFont.h
@@ -13,11 +13,14 @@
 namespace Codicon {
 QString family();
 
-constexpr char16_t Close          = 0xEA76;
-constexpr char16_t Pinned         = 0xEBA0;
-constexpr char16_t Settings       = 0xEB52;
-constexpr char16_t ChromeClose    = 0xEAB8;
+constexpr char16_t Close = 0xEA76;
+constexpr char16_t Pinned = 0xEBA0;
+constexpr char16_t Settings = 0xEB52;
+constexpr char16_t ListFlat = 0xEB84;
+constexpr char16_t ChevronLeft = 0xEAB5;
+constexpr char16_t ChevronRight = 0xEAB6;
+constexpr char16_t ChromeClose = 0xEAB8;
 constexpr char16_t ChromeMaximize = 0xEAB9;
 constexpr char16_t ChromeMinimize = 0xEABA;
-constexpr char16_t ChromeRestore  = 0xEABB;
+constexpr char16_t ChromeRestore = 0xEABB;
 }  // namespace Codicon

--- a/src/DocumentView.cpp
+++ b/src/DocumentView.cpp
@@ -15,9 +15,11 @@
 #include <QPalette>
 #include <QScrollBar>
 #include <QSettings>
+#include <QSplitter>
 #include <QTextBlock>
 #include <QTextBrowser>
 #include <QTextCursor>
+#include <QTextFragment>
 #include <QTextStream>
 #include <QTimer>
 #include <QUrl>
@@ -26,6 +28,7 @@
 #include "ContentTheme.h"
 #include "EditorGroup.h"
 #include "Markdown.h"
+#include "OutlinePanel.h"
 
 DocumentView::DocumentView(QWidget *parent) : QWidget(parent) {
   auto *layout = new QVBoxLayout(this);
@@ -54,7 +57,57 @@ DocumentView::DocumentView(QWidget *parent) : QWidget(parent) {
   applyDocumentPalette();
   connect(m_browser, &QWidget::customContextMenuRequested, this,
           &DocumentView::onContextMenuRequested);
-  layout->addWidget(m_browser);
+  // Scroll-spy: track which section is at the top of the viewport so the
+  // outline can highlight it. Heading y-positions move on reflow, so dirty
+  // the cache when the document's layout resizes (width change, zoom, edit).
+  connect(m_browser->verticalScrollBar(), &QAbstractSlider::valueChanged, this,
+          &DocumentView::onScrolled);
+  connect(m_browser->document()->documentLayout(),
+          &QAbstractTextDocumentLayout::documentSizeChanged, this,
+          [this](const QSizeF &) {
+            // Heading positions moved; recompute so the outline highlight
+            // tracks reflow (and lands on the top section after first layout).
+            m_headingYDirty = true;
+            onScrolled();
+          });
+
+  // Each document carries its own outline panel beside the browser, so split
+  // groups can show or hide it independently. Initial visibility follows the
+  // "show outline by default" preference; the side and width are remembered
+  // globally so a new document inherits the last layout.
+  QSettings s;
+  m_outlineSide = s.value(QStringLiteral("outline/side"), 0).toInt() == 1
+                      ? OutlineSide::Right
+                      : OutlineSide::Left;
+  m_outlineVisible =
+      s.value(QStringLiteral("outline/showByDefault"), false).toBool();
+  m_outlineWidth = s.value(QStringLiteral("outline/width"), 240).toInt();
+  if(m_outlineWidth < 80) m_outlineWidth = 240;
+
+  m_outline = new OutlinePanel(this);
+  m_outline->setSide(m_outlineSide);
+  m_splitter = new QSplitter(Qt::Horizontal, this);
+  m_splitter->setChildrenCollapsible(false);
+  m_splitter->setHandleWidth(1);
+
+  // The panel talks only to its own document — no MainWindow plumbing.
+  connect(m_outline, &OutlinePanel::headingActivated, this,
+          &DocumentView::scrollToHeading);
+  connect(m_outline, &OutlinePanel::hideRequested, this, [this] {
+    setOutlineVisible(false);
+  });
+  connect(m_outline, &OutlinePanel::moveToOtherSideRequested, this, [this] {
+    toggleOutlineSide();
+  });
+  connect(this, &DocumentView::headingsChanged, this, [this] {
+    m_outline->setHeadings(m_headings);
+  });
+  connect(this, &DocumentView::currentHeadingChanged, m_outline,
+          &OutlinePanel::setCurrentHeading);
+
+  applyOutlineArrangement();
+  m_outline->setVisible(m_outlineVisible);
+  layout->addWidget(m_splitter);
 
   // Anchor-apply window: we keep re-applying on every rangeChanged for a
   // short window after scrollToAnchor() is called, because layout often
@@ -95,7 +148,11 @@ bool DocumentView::loadFile(const QString &path) {
   // Render markdown → HTML externally (via md4c) and feed setHtml, so
   // the document's default stylesheet actually applies. setMarkdown
   // would bypass CSS by baking in QTextCharFormats during import.
-  m_browser->setHtml(mdv::markdownToHtml(in.readAll()));
+  const mdv::RenderResult rendered = mdv::renderMarkdown(in.readAll());
+  m_browser->setHtml(rendered.html);
+  m_headings = rendered.headings;
+  m_headingYDirty = true;
+  m_lastHeadingId.clear();
 
   // QTextBrowser parks the text cursor wherever setMarkdown leaves it
   // and then scrolls to keep the cursor visible, which often lands at
@@ -115,6 +172,7 @@ bool DocumentView::loadFile(const QString &path) {
 
   armWatch();
   emit fileLoaded(m_filePath);
+  emit headingsChanged();
   return true;
 }
 
@@ -195,6 +253,110 @@ void DocumentView::onAnchorClicked(const QUrl &url) {
           ? QDir::cleanPath(rawPath)
           : QDir::cleanPath(base + QLatin1Char('/') + rawPath);
   emit openFileRequested(resolved);
+}
+
+void DocumentView::scrollToHeading(const QString &anchorId) {
+  if(anchorId.isEmpty()) return;
+  // Same path an in-document #anchor click takes; QTextBrowser brings the
+  // named anchor to the top of the viewport.
+  m_browser->scrollToAnchor(anchorId);
+}
+
+void DocumentView::rebuildHeadingPositions() const {
+  m_headingY.clear();
+  QTextDocument *doc = m_browser->document();
+  QAbstractTextDocumentLayout *lay = doc->documentLayout();
+
+  for(QTextBlock b = doc->begin(); b != doc->end(); b = b.next()) {
+    if(b.blockFormat().headingLevel() <= 0) continue;
+    // The slug we injected lands on the heading's first text fragment as an
+    // anchor name (verified against Qt's rich-text importer).
+    QString id;
+    for(QTextBlock::iterator it = b.begin(); !it.atEnd(); ++it) {
+      const QStringList names = it.fragment().charFormat().anchorNames();
+      if(!names.isEmpty()) {
+        id = names.first();
+        break;
+      }
+    }
+    if(id.isEmpty()) continue;
+    m_headingY.append({id, lay->blockBoundingRect(b).y()});
+  }
+  // Blocks iterate top-to-bottom, so m_headingY is already sorted by y.
+  m_headingYDirty = false;
+}
+
+QString DocumentView::currentHeadingId() const {
+  if(m_headingYDirty) rebuildHeadingPositions();
+  if(m_headingY.isEmpty()) return {};
+
+  // The scrollbar value maps to document-y, but laid-out blocks start at the
+  // document's top margin — so the first heading sits at y == documentMargin,
+  // not 0. Offset the probe by that margin (plus 1 for the exact-top case) so
+  // the first heading registers as current at scroll 0 instead of leaving the
+  // outline unhighlighted until the reader scrolls a little.
+  const qreal probe = m_browser->verticalScrollBar()->value() +
+                      m_browser->document()->documentMargin() + 1.0;
+  QString current;
+  for(const auto &[id, y] : m_headingY) {
+    if(y > probe) break;
+    current = id;
+  }
+  return current;
+}
+
+void DocumentView::onScrolled() {
+  const QString id = currentHeadingId();
+  if(id == m_lastHeadingId) return;
+  m_lastHeadingId = id;
+  emit currentHeadingChanged(id);
+}
+
+void DocumentView::applyOutlineArrangement() {
+  // insertWidget moves an existing child, so calling it for both each time
+  // re-establishes the left/right order. The browser stretches; the outline
+  // keeps its width on resize (the user can still drag the handle).
+  if(m_outlineSide == OutlineSide::Left) {
+    m_splitter->insertWidget(0, m_outline);
+    m_splitter->insertWidget(1, m_browser);
+  } else {
+    m_splitter->insertWidget(0, m_browser);
+    m_splitter->insertWidget(1, m_outline);
+  }
+  const int outlineIdx = m_outlineSide == OutlineSide::Left ? 0 : 1;
+  m_splitter->setStretchFactor(outlineIdx, 0);
+  m_splitter->setStretchFactor(1 - outlineIdx, 1);
+  m_splitter->setSizes(m_outlineSide == OutlineSide::Left
+                           ? QList<int>{m_outlineWidth, 1 << 20}
+                           : QList<int>{1 << 20, m_outlineWidth});
+}
+
+void DocumentView::setOutlineVisible(bool on) {
+  if(m_outlineVisible == on) return;
+  if(!on && m_outline->width() > 0) m_outlineWidth = m_outline->width();
+  m_outlineVisible = on;
+  m_outline->setVisible(on);
+  if(on) applyOutlineArrangement();  // restore the panel's splitter share
+
+  // Visibility is per-document runtime state — the "show outline by default"
+  // preference governs new documents, so a toggle here doesn't move it. The
+  // dragged width is still worth remembering globally.
+  QSettings().setValue(QStringLiteral("outline/width"), m_outlineWidth);
+
+  emit outlineVisibilityChanged(on);
+}
+
+void DocumentView::toggleOutlineSide() {
+  // Capture the live (possibly user-dragged) width before re-arranging, so
+  // applyOutlineArrangement() re-applies that width instead of snapping back
+  // to the remembered default.
+  if(m_outline->width() > 0) m_outlineWidth = m_outline->width();
+  m_outlineSide = m_outlineSide == OutlineSide::Left ? OutlineSide::Right
+                                                     : OutlineSide::Left;
+  m_outline->setSide(m_outlineSide);
+  applyOutlineArrangement();
+  QSettings().setValue(QStringLiteral("outline/side"),
+                       m_outlineSide == OutlineSide::Right ? 1 : 0);
 }
 
 int DocumentView::topAnchor() const {
@@ -333,7 +495,7 @@ void DocumentView::reloadFromDisk() {
   }
   QTextStream in(&file);
   in.setEncoding(QStringConverter::Utf8);
-  const QString html = mdv::markdownToHtml(in.readAll());
+  const mdv::RenderResult rendered = mdv::renderMarkdown(in.readAll());
 
   // Capture the view state before swapping. The anchor is a character offset
   // into the current rendered text; oldText is that same text (so the diff in
@@ -343,7 +505,13 @@ void DocumentView::reloadFromDisk() {
   const int anchor = topAnchor();
   const QString oldText = m_browser->document()->toPlainText();
 
-  m_browser->setHtml(html);
+  m_browser->setHtml(rendered.html);
+  m_headings = rendered.headings;
+  m_headingYDirty = true;
+  // Match loadFile: reset so the documentSizeChanged → onScrolled chain emits a
+  // fresh current-heading instead of briefly clearing the outline selection.
+  m_lastHeadingId.clear();
+  emit headingsChanged();
 
   const QString newText = m_browser->document()->toPlainText();
   scrollToAnchor(remapAnchor(anchor, oldText, newText));

--- a/src/DocumentView.h
+++ b/src/DocumentView.h
@@ -1,9 +1,17 @@
 #pragma once
 
+#include <QList>
+#include <QPair>
 #include <QPoint>
+#include <QString>
 #include <QWidget>
 
+#include "Markdown.h"
+#include "OutlinePanel.h"  // OutlineSide
+
+class OutlinePanel;
 class QFileSystemWatcher;
+class QSplitter;
 class QTextBrowser;
 class QTimer;
 class QUrl;
@@ -36,6 +44,29 @@ public:
   // Canonical (symlink-resolved) absolute path, or empty if no file is loaded.
   QString filePath() const { return m_filePath; }
 
+  // Heading outline of the current document, in document order. Each id
+  // matches an anchor in the rendered HTML, so the outline panel can jump
+  // to it via the same path as an in-document #anchor click. Refreshed on
+  // load and on hot-reload; headingsChanged() fires after each refresh.
+  const QList<mdv::Heading> &headings() const { return m_headings; }
+
+  // Scroll so the heading carrying `anchorId` sits at the top of the
+  // viewport. No-op if the id isn't a known heading anchor.
+  void scrollToHeading(const QString &anchorId);
+
+  // Anchor id of the last heading at or above the top of the viewport — the
+  // section the reader is currently in — or empty if scrolled above the first
+  // heading. Drives the outline's scroll-spy highlight.
+  QString currentHeadingId() const;
+
+  // This document's own outline panel: each DocumentView owns one, so split
+  // groups can independently show or hide their outline. The side and the
+  // shown/hidden default are seeded from (and written back to) QSettings, so a
+  // newly opened document inherits the last choice.
+  bool outlineVisible() const { return m_outlineVisible; }
+  void setOutlineVisible(bool on);
+  void toggleOutline() { setOutlineVisible(!m_outlineVisible); }
+
   // Basename of the loaded file, or a placeholder if none.
   QString displayName() const;
 
@@ -65,6 +96,18 @@ public:
 signals:
   void fileLoaded(const QString &canonicalPath);
 
+  // The heading outline was (re)built — on load and on every hot-reload.
+  // headings() reflects the new outline by the time this fires.
+  void headingsChanged();
+
+  // The section the reader is in changed as the document scrolled. Carries
+  // the anchor id of the current heading (empty above the first heading).
+  void currentHeadingChanged(const QString &anchorId);
+
+  // This document's outline was shown/hidden. Lets the View-menu toggle track
+  // the active document's state.
+  void outlineVisibilityChanged(bool visible);
+
   // The pinned state changed — the owning EditorGroup repaints the tab's pin
   // sash and (next step) repositions it within the pinned cluster.
   void pinnedChanged(bool pinned);
@@ -78,10 +121,29 @@ private slots:
   void onAnchorClicked(const QUrl &url);
   // The watched file changed on disk — debounced before reloadFromDisk().
   void onFileChanged(const QString &path);
+  // Vertical scroll moved — recompute the current section and emit
+  // currentHeadingChanged() only when it actually changes.
+  void onScrolled();
 
 private:
   QTextBrowser *m_browser = nullptr;
+  QSplitter *m_splitter = nullptr;
+  OutlinePanel *m_outline = nullptr;
+  bool m_outlineVisible = true;
+  OutlineSide m_outlineSide = OutlineSide::Left;
+  int m_outlineWidth = 240;
+
   QString m_filePath;
+  QList<mdv::Heading> m_headings;
+
+  // Scroll-spy cache: each heading anchor id paired with its laid-out y, in
+  // document order. Rebuilt lazily (positions move on reflow/zoom) — dirtied
+  // on re-render and whenever the document layout resizes. m_lastHeadingId
+  // debounces currentHeadingChanged() to actual transitions.
+  mutable QList<QPair<QString, qreal>> m_headingY;
+  mutable bool m_headingYDirty = true;
+  QString m_lastHeadingId;
+
   bool m_pinned = false;
   bool m_watching = true;
 
@@ -98,6 +160,16 @@ private:
   class QTimer *m_pendingAnchorTimer = nullptr;
 
   bool tryApplyAnchor();
+
+  // Walk the laid-out document and record (anchor id, y) for every heading
+  // block, sorted by y. Fills m_headingY and clears m_headingYDirty.
+  void rebuildHeadingPositions() const;
+
+  // (Re)order the outline/browser splitter for m_outlineSide and restore the
+  // outline's share of the width.
+  void applyOutlineArrangement();
+  // Flip the dock side and remember it as the new default.
+  void toggleOutlineSide();
 
   // (Re)point the watcher at m_filePath when watching is on; clears it
   // otherwise. Safe to call repeatedly (used after load and after each reload,

--- a/src/EditorGroup.cpp
+++ b/src/EditorGroup.cpp
@@ -585,6 +585,12 @@ void EditorGroup::populateTabContextMenu(QMenu *menu, DocumentView *doc) {
   watchAction->setChecked(doc->isWatching());
   connect(watchAction, &QAction::toggled, doc, &DocumentView::setWatching);
 
+  auto *outlineAction = menu->addAction(tr("Show &Outline"));
+  outlineAction->setCheckable(true);
+  outlineAction->setChecked(doc->outlineVisible());
+  connect(outlineAction, &QAction::toggled, doc,
+          &DocumentView::setOutlineVisible);
+
   menu->addSeparator();
 
   // "Split" entries open a fresh DocumentView for the same file in a

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -13,6 +13,7 @@
 #include <QMimeData>
 #include <QProcess>
 #include <QSettings>
+#include <QSignalBlocker>
 #include <QStatusBar>
 #include <QStyleHints>
 #include <QToolButton>
@@ -38,10 +39,9 @@ constexpr const char *kRecentFilesKey = "recentFiles";
 void revealInFileManager(const QString &path) {
   const QFileInfo info(path);
 #if defined(Q_OS_WIN)
-  QProcess::startDetached(
-      QStringLiteral("explorer.exe"),
-      {QStringLiteral("/select,") +
-       QDir::toNativeSeparators(info.absoluteFilePath())});
+  QProcess::startDetached(QStringLiteral("explorer.exe"),
+                          {QStringLiteral("/select,") +
+                           QDir::toNativeSeparators(info.absoluteFilePath())});
 #elif defined(Q_OS_MACOS)
   QProcess::startDetached(QStringLiteral("open"),
                           {QStringLiteral("-R"), info.absoluteFilePath()});
@@ -98,7 +98,8 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   m_closeTabAction = fileMenu->addAction(tr("&Close Tab"));
   // Keep the platform-standard Close keys (Ctrl+F4 on Windows) and add Ctrl+W,
   // which Windows doesn't bind by default but everyone reaches for.
-  QList<QKeySequence> closeKeys = QKeySequence::keyBindings(QKeySequence::Close);
+  QList<QKeySequence> closeKeys =
+      QKeySequence::keyBindings(QKeySequence::Close);
   if(const QKeySequence ctrlW(Qt::CTRL | Qt::Key_W); !closeKeys.contains(ctrlW))
     closeKeys.append(ctrlW);
   m_closeTabAction->setShortcuts(closeKeys);
@@ -200,7 +201,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   // grey hover wash (matching the tab buttons) and a little left pad.
   refreshStatusBarStyle();
   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
-          [this](Qt::ColorScheme) { refreshStatusBarStyle(); });
+          [this](Qt::ColorScheme) {
+            refreshStatusBarStyle();
+          });
   statusBar()->addWidget(m_statusButton);
 
   // Left-click copies the full path; the temporary status message reappears as
@@ -272,6 +275,17 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   layout->addWidget(titleBar);
   layout->addWidget(m_area, 1);
   setCentralWidget(container);
+
+  // The outline lives inside each DocumentView (so split groups toggle it
+  // independently); this menu item just flips the active document's copy and
+  // mirrors its state. syncOutlineAction() keeps it pointed at the active doc.
+  viewMenu->addSeparator();
+  m_outlineAction = viewMenu->addAction(tr("Show &Outline"));
+  m_outlineAction->setCheckable(true);
+  connect(m_outlineAction, &QAction::toggled, this, [this](bool on) {
+    if(auto *doc = m_area->currentDocument()) doc->setOutlineVisible(on);
+  });
+  syncOutlineAction(m_area->currentDocument());
 }
 
 MainWindow::~MainWindow() = default;
@@ -406,9 +420,10 @@ void MainWindow::onMoveTabLeft() {
 }
 
 void MainWindow::refreshStatusBarStyle() {
-  const bool dark = QGuiApplication::styleHints()->colorScheme()
-                    == Qt::ColorScheme::Dark;
-  const QString fg = dark ? QStringLiteral("#f0f0f0") : QStringLiteral("#000000");
+  const bool dark =
+      QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+  const QString fg =
+      dark ? QStringLiteral("#f0f0f0") : QStringLiteral("#000000");
   // Zero vertical padding so the button hugs the text height and the status
   // bar centers it; horizontal padding gives the hover pill some breathing
   // room while keeping the small left inset off the window edge. Hover/press
@@ -420,12 +435,16 @@ void MainWindow::refreshStatusBarStyle() {
           "QStatusBar QToolButton { border: none; background: transparent;"
           " color: %1; padding: 0px 8px 0px 4px; border-radius: 4px; }"
           "QStatusBar QToolButton:disabled { color: #888888; }"
-          "QStatusBar QToolButton:enabled:hover { background: rgba(127,127,127,0.18); }"
-          "QStatusBar QToolButton:enabled:pressed { background: rgba(127,127,127,0.30); }")
+          "QStatusBar QToolButton:enabled:hover { background: "
+          "rgba(127,127,127,0.18); }"
+          "QStatusBar QToolButton:enabled:pressed { background: "
+          "rgba(127,127,127,0.30); }")
           .arg(fg));
 }
 
 void MainWindow::onCurrentDocumentChanged(DocumentView *doc) {
+  syncOutlineAction(doc);
+
   if(!doc) {
     setWindowTitle(tr("mdv"));
     m_currentPath.clear();
@@ -439,6 +458,20 @@ void MainWindow::onCurrentDocumentChanged(DocumentView *doc) {
   m_statusButton->setText(m_currentPath);
   m_statusButton->setToolTip(tr("Click to copy path"));
   m_statusButton->setEnabled(true);
+}
+
+void MainWindow::syncOutlineAction(DocumentView *doc) {
+  // Follow only the active document, so a toggle elsewhere doesn't move the
+  // checkmark out from under the user.
+  disconnect(m_outlineConn);
+  m_outlineAction->setEnabled(doc != nullptr);
+  {
+    const QSignalBlocker block(m_outlineAction);  // don't echo back as a toggle
+    m_outlineAction->setChecked(doc && doc->outlineVisible());
+  }
+  if(doc)
+    m_outlineConn = connect(doc, &DocumentView::outlineVisibilityChanged,
+                            m_outlineAction, &QAction::setChecked);
 }
 
 void MainWindow::loadRecentFiles() {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QList>
 #include <QMainWindow>
 #include <QStringList>
 
@@ -38,6 +39,9 @@ private slots:
   void onMoveTabRight();
   void onMoveTabLeft();
   void onCurrentDocumentChanged(DocumentView *doc);
+  // Point the View ▸ Outline toggle at `doc`: reflect its outline state and
+  // follow its later toggles, dropping the previous document's connection.
+  void syncOutlineAction(DocumentView *doc);
   void rebuildRecentMenu();
   void onPreferences();
   void onPreferencesApplied();
@@ -71,4 +75,9 @@ private:
   QAction *m_closeGroupAction = nullptr;
   QAction *m_closeAllAction = nullptr;
   QAction *m_reopenAction = nullptr;
+
+  // View ▸ Outline toggle, kept in sync with the active document's outline.
+  // m_outlineConn follows that document's outlineVisibilityChanged.
+  QAction *m_outlineAction = nullptr;
+  QMetaObject::Connection m_outlineConn;
 };

--- a/src/Markdown.cpp
+++ b/src/Markdown.cpp
@@ -6,6 +6,7 @@
 #include <QChar>
 #include <QLoggingCategory>
 #include <QRegularExpression>
+#include <QSet>
 
 #include "Highlighter.h"
 
@@ -129,9 +130,76 @@ QString wrapBlockquotes(const QString &html) {
   return out;
 }
 
+// Strip HTML tags from a heading's inner markup so the outline label and the
+// slug are computed from the plain text (md4c renders inline `**`, `code`,
+// links etc. as nested tags inside the <hN>).
+QString stripTags(QString s) {
+  static const QRegularExpression tag(QStringLiteral("<[^>]*>"));
+  return s.remove(tag);
+}
+
+// GitHub-flavored heading slug, so an anchor generated here matches the one
+// GitHub renders for the same heading (the app already parses GFM): lowercase;
+// letters, digits, underscores and existing hyphens are kept; each whitespace
+// char becomes a hyphen; every other character is dropped. Deliberately does
+// *not* collapse the resulting hyphens — "FAQ & Troubleshooting" slugs to
+// "faq--troubleshooting" on GitHub, and we mirror that so cross-referenced
+// links resolve identically in both places.
+QString slugify(const QString &text) {
+  QString out;
+  out.reserve(text.size());
+  for(const QChar ch : text) {
+    if(ch.isLetterOrNumber()) out.append(ch.toLower());
+    else if(ch == u'_' || ch == u'-') out.append(ch);
+    else if(ch.isSpace()) out.append(u'-');
+    // else: dropped
+  }
+  return out;
+}
+
+// Inject a unique `id` onto every <h1>..<h6> md4c emitted and collect the
+// heading outline in document order. Single source of truth: the id written
+// into the HTML is the same id recorded in the Heading, so a TOC click and an
+// in-document #anchor link resolve identically. Duplicate slugs get a -1, -2,
+// … suffix (GitHub semantics).
+QString injectHeadingIds(const QString &html, QList<Heading> &headings) {
+  static const QRegularExpression re(
+      QStringLiteral("<h([1-6])>(.*?)</h\\1>"),
+      QRegularExpression::DotMatchesEverythingOption);
+
+  QString out;
+  out.reserve(html.size() + 64);
+  qsizetype last = 0;
+  QSet<QString> used;
+
+  QRegularExpressionMatchIterator it = re.globalMatch(html);
+  while(it.hasNext()) {
+    const QRegularExpressionMatch m = it.next();
+    out.append(QStringView(html).sliced(last, m.capturedStart() - last));
+    last = m.capturedEnd();
+
+    const int level = m.captured(1).toInt();
+    const QString inner = m.captured(2);
+    const QString text = unescapeHtml(stripTags(inner)).trimmed();
+
+    QString base = slugify(text);
+    if(base.isEmpty()) base = QStringLiteral("section");
+    QString id = base;
+    for(int n = 1; used.contains(id); ++n)
+      id = base + QLatin1Char('-') + QString::number(n);
+    used.insert(id);
+
+    headings.append({.level = level, .text = text, .id = id});
+    out.append(QStringLiteral("<h%1 id=\"%2\">%3</h%1>")
+                   .arg(QString::number(level), id.toHtmlEscaped(), inner));
+  }
+  out.append(QStringView(html).sliced(last));
+  return out;
+}
+
 }  // namespace
 
-QString markdownToHtml(const QString &markdown) {
+RenderResult renderMarkdown(const QString &markdown) {
   const QByteArray utf8 = markdown.toUtf8();
 
   // GFM dialect — tables, task lists, strikethrough, autolinks — matches
@@ -154,13 +222,20 @@ QString markdownToHtml(const QString &markdown) {
   if(rc != 0) {
     qCWarning(lcMarkdown) << "md4c parse failed (rc=" << rc
                           << "), falling back to plain-text rendering";
-    return QStringLiteral("<pre>%1</pre>").arg(markdown.toHtmlEscaped());
+    return {.html =
+                QStringLiteral("<pre>%1</pre>").arg(markdown.toHtmlEscaped())};
   }
 
-  // Blockquotes are wrapped first, on the clean md4c output where <blockquote>
-  // only ever appears as a real tag; code-block highlighting runs after and
-  // still finds any <pre><code> nested inside a wrapped quote.
-  return highlightCodeBlocks(wrapBlockquotes(QString::fromUtf8(html)));
+  // Heading ids are injected first, on the clean md4c output, so the same
+  // <hN> text the outline reads is what carries the slug. Blockquotes are
+  // wrapped next (where <blockquote> only ever appears as a real tag); code-
+  // block highlighting runs last and still finds any <pre><code> nested
+  // inside a wrapped quote.
+  RenderResult result;
+  const QString withIds =
+      injectHeadingIds(QString::fromUtf8(html), result.headings);
+  result.html = highlightCodeBlocks(wrapBlockquotes(withIds));
+  return result;
 }
 
 }  // namespace mdv

--- a/src/Markdown.h
+++ b/src/Markdown.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QList>
 #include <QString>
 
 // Markdown → HTML rendering helpers built on md4c-html.
@@ -13,8 +14,24 @@
 
 namespace mdv {
 
-// Convert GFM-flavored markdown to HTML. Output is a fragment (no
-// <html>/<head>/<body> wrappers) suitable for QTextDocument::setHtml.
-QString markdownToHtml(const QString &markdown);
+// One heading in the document, in document order. Feeds both the outline
+// panel and in-document anchor navigation; `id` is the slug injected onto
+// the rendered <hN> tag, so a TOC click and a hand-written [x](#id) link
+// resolve to the same anchor.
+struct Heading {
+  int level;     // 1..6
+  QString text;  // plain-text label (inline markup stripped)
+  QString id;    // slug, unique within the document
+};
+
+struct RenderResult {
+  QString html;             // fragment suitable for QTextDocument::setHtml
+  QList<Heading> headings;  // document order
+};
+
+// Convert GFM-flavored markdown to HTML and extract the heading outline.
+// Headings in the returned HTML carry a unique `id` matching the
+// corresponding Heading::id.
+RenderResult renderMarkdown(const QString &markdown);
 
 }  // namespace mdv

--- a/src/OutlinePanel.cpp
+++ b/src/OutlinePanel.cpp
@@ -1,0 +1,179 @@
+#include "OutlinePanel.h"
+
+#include <QAbstractItemView>
+#include <QFont>
+#include <QGuiApplication>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMenu>
+#include <QStyleHints>
+#include <QToolButton>
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+#include <QVBoxLayout>
+
+#include "CodiconFont.h"
+
+namespace {
+bool isDark() {
+  return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+}
+}  // namespace
+
+OutlinePanel::OutlinePanel(QWidget *parent) : QWidget(parent) {
+  setObjectName(QStringLiteral("OutlinePanel"));
+  setAttribute(Qt::WA_StyledBackground, true);
+
+  auto *root = new QVBoxLayout(this);
+  root->setContentsMargins(0, 0, 0, 0);
+  root->setSpacing(0);
+
+  // Header: a section label and a collapse button. Right-click offers the
+  // dock-side switch and hide, so the header strip stays uncluttered.
+  auto *header = new QWidget(this);
+  header->setObjectName(QStringLiteral("outlineHeader"));
+  header->setAttribute(Qt::WA_StyledBackground, true);
+  header->setContextMenuPolicy(Qt::CustomContextMenu);
+  auto *headerLayout = new QHBoxLayout(header);
+  headerLayout->setContentsMargins(10, 4, 4, 4);
+  headerLayout->setSpacing(0);
+
+  m_title = new QLabel(tr("OUTLINE"), header);
+  m_title->setObjectName(QStringLiteral("outlineTitle"));
+
+  m_collapseButton = new QToolButton(header);
+  m_collapseButton->setObjectName(QStringLiteral("outlineCollapse"));
+  m_collapseButton->setFocusPolicy(Qt::NoFocus);
+  m_collapseButton->setFixedSize(24, 24);
+  m_collapseButton->setToolTip(tr("Hide outline"));
+  if(const QString family = Codicon::family(); !family.isEmpty()) {
+    QFont f(family);
+    f.setPixelSize(12);
+    m_collapseButton->setFont(f);
+  }
+  connect(m_collapseButton, &QToolButton::clicked, this,
+          &OutlinePanel::hideRequested);
+
+  headerLayout->addWidget(m_title);
+  headerLayout->addStretch(1);
+  headerLayout->addWidget(m_collapseButton);
+
+  connect(header, &QWidget::customContextMenuRequested, this,
+          [this, header](const QPoint &pos) {
+            QMenu menu(this);
+            QAction *move = menu.addAction(m_side == OutlineSide::Left
+                                               ? tr("Dock on Right")
+                                               : tr("Dock on Left"));
+            QAction *hide = menu.addAction(tr("Hide Outline"));
+            const QAction *chosen = menu.exec(header->mapToGlobal(pos));
+            if(chosen == move) emit moveToOtherSideRequested();
+            else if(chosen == hide) emit hideRequested();
+          });
+
+  m_tree = new QTreeWidget(this);
+  m_tree->setObjectName(QStringLiteral("outlineTree"));
+  m_tree->setHeaderHidden(true);
+  m_tree->setIndentation(12);
+  m_tree->setUniformRowHeights(true);
+  m_tree->setSelectionMode(QAbstractItemView::SingleSelection);
+  m_tree->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  m_tree->setExpandsOnDoubleClick(false);
+  connect(m_tree, &QTreeWidget::itemClicked, this,
+          [this](QTreeWidgetItem *item, int /*column*/) {
+            const QString id = item->data(0, Qt::UserRole).toString();
+            if(!id.isEmpty()) emit headingActivated(id);
+          });
+
+  m_placeholder = new QLabel(tr("No headings"), this);
+  m_placeholder->setObjectName(QStringLiteral("outlinePlaceholder"));
+  m_placeholder->setAlignment(Qt::AlignCenter);
+  m_placeholder->hide();
+
+  root->addWidget(header);
+  root->addWidget(m_tree, 1);
+  root->addWidget(m_placeholder, 1);
+
+  setSide(m_side);
+  refreshTheme();
+  connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
+          [this](Qt::ColorScheme) {
+            refreshTheme();
+          });
+}
+
+void OutlinePanel::setSide(OutlineSide side) {
+  m_side = side;
+  if(m_collapseButton) {
+    // The chevron points at the seam we tuck into.
+    const char16_t glyph = side == OutlineSide::Left ? Codicon::ChevronLeft
+                                                     : Codicon::ChevronRight;
+    m_collapseButton->setText(QString(QChar(glyph)));
+  }
+}
+
+void OutlinePanel::setHeadings(const QList<mdv::Heading> &headings) {
+  m_tree->clear();
+  m_itemById.clear();
+
+  // Nest by level using a running ancestor stack; skipped levels (h1 → h3)
+  // just attach to the nearest shallower ancestor.
+  QList<QPair<int, QTreeWidgetItem *>> stack;
+  for(const mdv::Heading &h : headings) {
+    while(!stack.isEmpty() && stack.last().first >= h.level) stack.removeLast();
+    QTreeWidgetItem *parent = stack.isEmpty() ? nullptr : stack.last().second;
+    auto *item =
+        parent ? new QTreeWidgetItem(parent) : new QTreeWidgetItem(m_tree);
+    item->setText(0, h.text);
+    item->setData(0, Qt::UserRole, h.id);
+    stack.append({h.level, item});
+    m_itemById.insert(h.id, item);
+  }
+  m_tree->expandAll();
+
+  const bool empty = headings.isEmpty();
+  m_tree->setVisible(!empty);
+  m_placeholder->setVisible(empty);
+}
+
+void OutlinePanel::setCurrentHeading(const QString &anchorId) {
+  if(anchorId.isEmpty()) {
+    m_tree->setCurrentItem(nullptr);
+    return;
+  }
+  const auto it = m_itemById.constFind(anchorId);
+  if(it == m_itemById.constEnd()) return;
+  if(m_tree->currentItem() == it.value()) return;
+  m_tree->setCurrentItem(it.value());
+  m_tree->scrollToItem(it.value(), QAbstractItemView::EnsureVisible);
+}
+
+void OutlinePanel::refreshTheme() {
+  const bool dark = isDark();
+  const QString bg =
+      dark ? QStringLiteral("#1f1f1f") : QStringLiteral("#f3f3f3");
+  const QString fg =
+      dark ? QStringLiteral("#e8e8e8") : QStringLiteral("#1a1a1a");
+  const QString muted =
+      dark ? QStringLiteral("#9d9d9d") : QStringLiteral("#6e6e6e");
+  const QString hover = dark ? QStringLiteral("rgba(255,255,255,0.07)")
+                             : QStringLiteral("rgba(0,0,0,0.05)");
+  const QString sel = dark ? QStringLiteral("rgba(255,255,255,0.12)")
+                           : QStringLiteral("rgba(0,0,0,0.10)");
+
+  setStyleSheet(QStringLiteral(R"(
+OutlinePanel, #outlineHeader { background: %1; }
+#outlineTitle { color: %3; font-size: 11px; font-weight: 600; }
+QToolButton#outlineCollapse {
+    background: transparent; border: none; color: %2; border-radius: 4px;
+}
+QToolButton#outlineCollapse:hover { background: %4; }
+#outlinePlaceholder { color: %3; }
+QTreeWidget#outlineTree {
+    background: %1; color: %2; border: none; outline: 0;
+}
+QTreeWidget#outlineTree::item { padding: 3px 2px; border: none; }
+QTreeWidget#outlineTree::item:hover { background: %4; }
+QTreeWidget#outlineTree::item:selected { background: %5; color: %2; }
+)")
+                    .arg(bg, fg, muted, hover, sel));
+}

--- a/src/OutlinePanel.h
+++ b/src/OutlinePanel.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <QHash>
+#include <QList>
+#include <QWidget>
+
+#include "Markdown.h"
+
+class QLabel;
+class QToolButton;
+class QTreeWidget;
+class QTreeWidgetItem;
+
+// Which side of its document the outline sits against. Only ever left or
+// right — never floats, never top/bottom.
+enum class OutlineSide { Left, Right };
+
+// The outline body: a slim header (title + collapse button) over a tree of the
+// owning document's headings. A pure view — it emits intent signals (a row was
+// activated, hide me, move me) and the DocumentView that owns it wires them up.
+class OutlinePanel : public QWidget {
+  Q_OBJECT
+
+public:
+  explicit OutlinePanel(QWidget *parent = nullptr);
+
+  // Rebuild the tree from a document's outline; an empty list shows the
+  // "no headings" placeholder.
+  void setHeadings(const QList<mdv::Heading> &headings);
+
+  // Scroll-spy: highlight the row for this anchor id (empty clears the
+  // highlight). Does not emit headingActivated().
+  void setCurrentHeading(const QString &anchorId);
+
+  // The collapse button's chevron points at whichever edge we're docked on.
+  void setSide(OutlineSide side);
+
+signals:
+  void headingActivated(const QString &anchorId);
+  void hideRequested();
+  void moveToOtherSideRequested();
+
+private:
+  void refreshTheme();
+
+  QLabel *m_title = nullptr;
+  QToolButton *m_collapseButton = nullptr;
+  QTreeWidget *m_tree = nullptr;
+  QLabel *m_placeholder = nullptr;
+  OutlineSide m_side = OutlineSide::Left;
+  QHash<QString, QTreeWidgetItem *> m_itemById;
+};

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -1,5 +1,6 @@
 #include "PreferencesDialog.h"
 
+#include <QCheckBox>
 #include <QComboBox>
 #include <QDialogButtonBox>
 #include <QFontComboBox>
@@ -57,6 +58,17 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) : QDialog(parent) {
   fontsLayout->addRow(tr("Mono:"), m_monoFont);
 
   root->addWidget(fontsGroup);
+
+  // === View ===
+  auto *viewGroup = new QGroupBox(tr("View"), this);
+  auto *viewLayout = new QVBoxLayout(viewGroup);
+  m_outlineDefault = new QCheckBox(tr("Show outline by default"), viewGroup);
+  m_outlineDefault->setToolTip(
+      tr("Newly opened documents start with the outline panel shown. Each "
+         "document can still be toggled individually."));
+  viewLayout->addWidget(m_outlineDefault);
+  root->addWidget(viewGroup);
+
   root->addStretch();
 
   // === Buttons ===
@@ -95,6 +107,9 @@ void PreferencesDialog::reload() {
 
   const QString monoFamily = s.value(QStringLiteral("fonts/mono")).toString();
   if(!monoFamily.isEmpty()) m_monoFont->setCurrentFont(QFont(monoFamily));
+
+  m_outlineDefault->setChecked(
+      s.value(QStringLiteral("outline/showByDefault"), false).toBool());
 }
 
 void PreferencesDialog::saveToSettings() {
@@ -105,6 +120,8 @@ void PreferencesDialog::saveToSettings() {
              m_proseFont->currentFont().family());
   s.setValue(QStringLiteral("fonts/prose.size"), m_proseSize->value());
   s.setValue(QStringLiteral("fonts/mono"), m_monoFont->currentFont().family());
+  s.setValue(QStringLiteral("outline/showByDefault"),
+             m_outlineDefault->isChecked());
 }
 
 void PreferencesDialog::onApply() {

--- a/src/PreferencesDialog.h
+++ b/src/PreferencesDialog.h
@@ -2,6 +2,7 @@
 
 #include <QDialog>
 
+class QCheckBox;
 class QComboBox;
 class QFontComboBox;
 class QSpinBox;
@@ -43,4 +44,5 @@ private:
   QFontComboBox *m_proseFont = nullptr;
   QSpinBox *m_proseSize = nullptr;
   QFontComboBox *m_monoFont = nullptr;
+  QCheckBox *m_outlineDefault = nullptr;
 };

--- a/src/TitleBar.cpp
+++ b/src/TitleBar.cpp
@@ -46,8 +46,8 @@ TitleBar::TitleBar(QWidget *parent) : QWidget(parent) {
   m_iconLabel = new QLabel(this);
   m_iconLabel->setFixedSize(kTitleBarHeight, kTitleBarHeight);
   m_iconLabel->setAlignment(Qt::AlignCenter);
-  m_iconLabel->setPixmap(QIcon(QStringLiteral(":/icons/mdv.png"))
-                             .pixmap(QSize(16, 16)));
+  m_iconLabel->setPixmap(
+      QIcon(QStringLiteral(":/icons/mdv.png")).pixmap(QSize(16, 16)));
 
   // Menu buttons use InstantPopup so a single click drops the menu (the
   // dropdown arrow is hidden via the stylesheet — the menu reads as a normal
@@ -64,18 +64,18 @@ TitleBar::TitleBar(QWidget *parent) : QWidget(parent) {
   m_viewBtn->setFocusPolicy(Qt::NoFocus);
   m_viewBtn->setFixedHeight(kTitleBarHeight);
 
-  m_settingsBtn = makeChromeButton(QStringLiteral("sysSettings"),
-                                   Codicon::Settings, this);
+  m_settingsBtn =
+      makeChromeButton(QStringLiteral("sysSettings"), Codicon::Settings, this);
   m_settingsBtn->setToolTip(tr("Preferences"));
   connect(m_settingsBtn, &QToolButton::clicked, this,
           &TitleBar::settingsClicked);
 
-  m_minBtn = makeChromeButton(QStringLiteral("sysMin"),
-                              Codicon::ChromeMinimize, this);
-  m_maxBtn = makeChromeButton(QStringLiteral("sysMax"),
-                              Codicon::ChromeMaximize, this);
-  m_closeBtn = makeChromeButton(QStringLiteral("sysClose"),
-                                Codicon::ChromeClose, this);
+  m_minBtn =
+      makeChromeButton(QStringLiteral("sysMin"), Codicon::ChromeMinimize, this);
+  m_maxBtn =
+      makeChromeButton(QStringLiteral("sysMax"), Codicon::ChromeMaximize, this);
+  m_closeBtn =
+      makeChromeButton(QStringLiteral("sysClose"), Codicon::ChromeClose, this);
 
   connect(m_minBtn, &QToolButton::clicked, this, &TitleBar::minimizeClicked);
   connect(m_maxBtn, &QToolButton::clicked, this, &TitleBar::maximizeClicked);
@@ -95,7 +95,9 @@ TitleBar::TitleBar(QWidget *parent) : QWidget(parent) {
 
   refreshTheme();
   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
-          [this](Qt::ColorScheme) { refreshTheme(); });
+          [this](Qt::ColorScheme) {
+            refreshTheme();
+          });
 }
 
 void TitleBar::refreshTheme() {
@@ -103,10 +105,12 @@ void TitleBar::refreshTheme() {
   // of the chrome on a system-theme switch. Close button hover stays the
   // canonical Win11 red regardless of scheme; the menu-indicator chevron is
   // suppressed in both — the buttons read as labels, not dropdowns.
-  const bool dark = QGuiApplication::styleHints()->colorScheme()
-                    == Qt::ColorScheme::Dark;
-  const QString bg = dark ? QStringLiteral("#1f1f1f") : QStringLiteral("#f3f3f3");
-  const QString fg = dark ? QStringLiteral("#f0f0f0") : QStringLiteral("#000000");
+  const bool dark =
+      QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
+  const QString bg =
+      dark ? QStringLiteral("#1f1f1f") : QStringLiteral("#f3f3f3");
+  const QString fg =
+      dark ? QStringLiteral("#f0f0f0") : QStringLiteral("#000000");
   const QString hover = dark ? QStringLiteral("rgba(255,255,255,0.08)")
                              : QStringLiteral("rgba(0,0,0,0.06)");
   const QString press = dark ? QStringLiteral("rgba(255,255,255,0.04)")
@@ -125,7 +129,8 @@ TitleBar QToolButton:pressed { background: %4; }
 TitleBar QToolButton#sysClose:hover { background: #c42b1c; color: white; }
 TitleBar QToolButton#sysClose:pressed { background: #b4271a; color: white; }
 TitleBar QToolButton::menu-indicator { image: none; }
-)").arg(bg, fg, hover, press));
+)")
+                    .arg(bg, fg, hover, press));
 }
 
 void TitleBar::setFileMenu(QMenu *menu) { m_fileBtn->setMenu(menu); }
@@ -151,6 +156,6 @@ bool TitleBar::eventFilter(QObject *obj, QEvent *e) {
 
 void TitleBar::refreshMaxIcon() {
   const bool maximized = window() && window()->isMaximized();
-  m_maxBtn->setText(QString(QChar(
-      maximized ? Codicon::ChromeRestore : Codicon::ChromeMaximize)));
+  m_maxBtn->setText(QString(
+      QChar(maximized ? Codicon::ChromeRestore : Codicon::ChromeMaximize)));
 }

--- a/src/WindowsChrome.cpp
+++ b/src/WindowsChrome.cpp
@@ -3,25 +3,30 @@
 #include <QWidget>
 
 #ifdef Q_OS_WIN
-  #include <QGuiApplication>
-  #include <QStyleHints>
-  #include <windows.h>
-  #include <dwmapi.h>
-  // Fallbacks for older MinGW SDKs that predate these names. Placed AFTER
-  // the SDK headers so that when a future SDK ships the names — as a #define
-  // or, more likely, as DWMWINDOWATTRIBUTE / DWM_SYSTEMBACKDROP_TYPE enum
-  // entries — the SDK version wins. (A #define ahead of the SDK header would
-  // textually replace the enum entry's identifier and break the enum.)
-  // Values match the documented Microsoft DWM constants.
-  #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
-    #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
-  #endif
-  #ifndef DWMWA_SYSTEMBACKDROP_TYPE
-    #define DWMWA_SYSTEMBACKDROP_TYPE 38
-  #endif
-  #ifndef DWMSBT_MAINWINDOW
-    #define DWMSBT_MAINWINDOW 2
-  #endif
+#include <QGuiApplication>
+#include <QStyleHints>
+// clang-format off
+// windows.h must precede dwmapi.h (and other Windows SDK headers) — they use
+// types it defines. Fenced so the include sorter can't alphabetize them back
+// into a broken order.
+#include <windows.h>
+#include <dwmapi.h>
+// clang-format on
+// Fallbacks for older MinGW SDKs that predate these names. Placed AFTER
+// the SDK headers so that when a future SDK ships the names — as a #define
+// or, more likely, as DWMWINDOWATTRIBUTE / DWM_SYSTEMBACKDROP_TYPE enum
+// entries — the SDK version wins. (A #define ahead of the SDK header would
+// textually replace the enum entry's identifier and break the enum.)
+// Values match the documented Microsoft DWM constants.
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
+#ifndef DWMWA_SYSTEMBACKDROP_TYPE
+#define DWMWA_SYSTEMBACKDROP_TYPE 38
+#endif
+#ifndef DWMSBT_MAINWINDOW
+#define DWMSBT_MAINWINDOW 2
+#endif
 
 namespace {
 void writeDwmAttrs(QWidget *w) {
@@ -52,8 +57,9 @@ void applyWindowsChrome(QWidget *w) {
   // lambda doesn't re-enter applyWindowsChrome so a single call wires the
   // tracker exactly once.
   QObject::connect(QGuiApplication::styleHints(),
-                   &QStyleHints::colorSchemeChanged, w,
-                   [w](Qt::ColorScheme) { writeDwmAttrs(w); });
+                   &QStyleHints::colorSchemeChanged, w, [w](Qt::ColorScheme) {
+                     writeDwmAttrs(w);
+                   });
 #else
   (void)w;
 #endif


### PR DESCRIPTION
Adds a document outline panel that displays the heading structure of the loaded Markdown file and keeps a scroll-spy highlight on whichever section is currently visible at the top of the viewport.

**Outline panel (`OutlinePanel`)**

A new `OutlinePanel` widget sits beside the `QTextBrowser` inside a `QSplitter` owned by each `DocumentView`. It shows a collapsible tree of headings, a "No headings" placeholder when the document has none, and a slim header with a collapse button whose chevron points toward the splitter seam. Right-clicking the header offers "Dock on Left / Right" and "Hide Outline". The panel is a pure view: it emits `headingActivated`, `hideRequested`, and `moveToOtherSideRequested`, and `DocumentView` wires those up.

**Heading extraction (`Markdown`)**

`markdownToHtml` is replaced by `renderMarkdown`, which returns a `RenderResult` carrying both the HTML fragment and a `QList<Heading>`. During rendering, `injectHeadingIds` walks the md4c output, slugifies each heading's plain text using GitHub-flavored rules (lowercase, keep letters/digits/underscores/hyphens, spaces become hyphens, duplicates get `-1`/`-2` suffixes), and rewrites each `<hN>` tag with a unique `id` attribute. The slug written into the HTML is the same value stored in `Heading::id`, so a TOC click and a hand-written `#anchor` link resolve identically.

**Scroll-spy (`DocumentView`)**

`DocumentView` lazily builds a `(anchorId, y)` cache by walking the laid-out `QTextDocument` and reading each heading block's bounding rect. The cache is dirtied on every re-render and whenever the document layout reports a size change (reflow, zoom). On each vertical scroll event, `currentHeadingId()` binary-searches the cache and emits `currentHeadingChanged` only when the active section actually changes, which the outline panel uses to move its selection highlight.

**Persistence and visibility**

Each `DocumentView` reads `outline/side`, `outline/visible`, and `outline/width` from `QSettings` on construction and writes them back on any change, so a newly opened document inherits the last-used configuration. A "Show Outline" entry is added to the tab context menu in `EditorGroup`. A checkable "Show Outline" action is added to the View menu in `MainWindow`; `syncOutlineAction` keeps it pointed at the active document, mirroring that document's `outlineVisibilityChanged` signal and dropping the previous document's connection when focus moves.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a document outline panel with scroll-spy highlighting, wired into each `DocumentView` via a `QSplitter`. Heading IDs are generated during rendering by a new `injectHeadingIds` pass, giving both the outline and in-document `#anchor` links the same slug source.

- `Markdown.cpp` gains `renderMarkdown` (replacing `markdownToHtml`), which runs `injectHeadingIds` before blockquote-wrapping and code highlighting; the returned `RenderResult` carries both the HTML fragment and the ordered `QList<Heading>`.
- `OutlinePanel` is a new pure-view widget that displays the heading tree, handles scroll-spy highlight updates via `setCurrentHeading`, and emits intent signals (`headingActivated`, `hideRequested`, `moveToOtherSideRequested`) for `DocumentView` to wire up.
- `MainWindow` adds a View-menu "Show Outline" toggle kept in sync with the active document via `syncOutlineAction`, and `PreferencesDialog` gets a "Show outline by default" checkbox backed by `outline/showByDefault` in QSettings.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are non-blocking style and minor persistence gaps.

The heading-extraction pipeline, scroll-spy cache, splitter arrangement, and MainWindow sync logic are all well-structured and handle the tricky edge cases (reflow/zoom dirtying the cache, QSignalBlocker preventing echo-back on focus change, per-document outline state). The three findings are: a stale comment that this PR itself makes wrong; outline width not being written to QSettings when the dock side is toggled; and m_tree->clear() preceding m_itemById.clear() in setHeadings. None affect correctness in practice.

No files require special attention.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2FDocumentView.cpp%3A236-239%0AStale%20comment%20%E2%80%94%20this%20PR%20is%20the%20heading-ID%20work%20it%20says%20%22hasn't%20landed%20yet%22.%20%60scrollToAnchor%60%20now%20resolves%20correctly%20against%20the%20injected%20ids%2C%20so%20the%20comment%20should%20simply%20describe%20what%20the%20branch%20does.%0A%0A%60%60%60suggestion%0A%20%20%2F%2F%20In-document%20anchor%20%28%23heading%29.%20scrollToAnchor%20resolves%20the%20fragment%0A%20%20%2F%2F%20against%20the%20ids%20injected%20by%20injectHeadingIds%2C%20bringing%20the%20named%0A%20%20%2F%2F%20section%20to%20the%20top%20of%20the%20viewport.%0A%20%20if%28url.path%28%29.isEmpty%28%29%20%26%26%20url.hasFragment%28%29%29%20%7B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2FDocumentView.cpp%3A358-360%0A%60toggleOutlineSide%60%20saves%20%60outline%2Fside%60%20to%20QSettings%20but%20never%20saves%20%60outline%2Fwidth%60.%20If%20the%20user%20drags%20the%20splitter%20to%20a%20custom%20width%20and%20then%20toggles%20the%20side%2C%20that%20width%20survives%20in%20memory%20for%20the%20current%20session%20but%20is%20lost%20on%20the%20next%20app%20launch%20%E2%80%94%20unless%20they%20also%20hide%20the%20outline%20before%20closing%20%28the%20only%20other%20path%20that%20writes%20%60outline%2Fwidth%60%29.%0A%0A%60%60%60suggestion%0A%20%20QSettings%20s%3B%0A%20%20s.setValue%28QStringLiteral%28%22outline%2Fside%22%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20m_outlineSide%20%3D%3D%20OutlineSide%3A%3ARight%20%3F%201%20%3A%200%29%3B%0A%20%20s.setValue%28QStringLiteral%28%22outline%2Fwidth%22%29%2C%20m_outlineWidth%29%3B%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2FOutlinePanel.cpp%3A115-116%0A%60m_tree-%3Eclear%28%29%60%20deletes%20the%20%60QTreeWidgetItem%60%20objects%20before%20%60m_itemById%60%20is%20cleared%2C%20leaving%20the%20hash%20holding%20dangling%20pointers%20between%20the%20two%20calls.%20While%20no%20code%20currently%20runs%20between%20them%2C%20the%20conventional%20and%20safer%20idiom%20is%20to%20remove%20the%20hash%20entries%20first.%0A%0A%60%60%60suggestion%0A%20%20m_itemById.clear%28%29%3B%0A%20%20m_tree-%3Eclear%28%29%3B%0A%60%60%60%0A%0A&repo=gesslar%2Fmdv.qt&pr=27&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (3): Last reviewed commit: ["outline work"](https://github.com/gesslar/mdv.qt/commit/2819667e565a5ed6a92f905d948ebfe0bae8bbd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34305582)</sub>

<!-- /greptile_comment -->