### PR TITLE
bump to 2.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(mdv
-    VERSION 2.1.0
+    VERSION 2.2.0
     DESCRIPTION "An offline Markdown viewer for everybody! For free! Huzzah!"
     LANGUAGES CXX
 )


### PR DESCRIPTION
Bump version to 2.2.0

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the project version from `2.1.0` to `2.2.0` in `CMakeLists.txt`.

- The only change is the `VERSION` field in the `project()` call, updated from `2.1.0` to `2.2.0`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line version bump with no functional impact.

The entire change is updating the CMake project version string from `2.1.0` to `2.2.0`. Nothing in the build logic, dependencies, or code paths is affected.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["bump"](https://github.com/gesslar/mdv.qt/commit/e5b036570958aa76d84f67ff80dd1dbd63d9ca83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34309079)</sub>

<!-- /greptile_comment -->