### PR TITLE
bump to 2.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(mdv
-    VERSION 2.2.0
+    VERSION 2.3.0
     DESCRIPTION "An offline Markdown viewer for everybody! For free! Huzzah!"
     LANGUAGES CXX
 )


### PR DESCRIPTION
Bumps the project version from 2.2.0 to 2.3.0.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the project version from `2.2.0` to `2.3.0` in `CMakeLists.txt`.

- Single-line change updating `VERSION 2.2.0` to `VERSION 2.3.0` in the CMake project definition — no logic, build configuration, or source code is modified.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line version string update with no effect on build logic or runtime behavior.

The only change is a version string bump in the CMake project declaration. No source files, build rules, dependencies, or configuration are touched.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["bump"](https://github.com/gesslar/mdv.qt/commit/e56cafe8dad46bc826f9bcaa51783ad6cb5b111f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34423491)</sub>

<!-- /greptile_comment -->