### PR TITLE
fix anchor restore overshoot by subtracting documentMargin from scroll target

### DIFF
--- a/src/DocumentView.cpp
+++ b/src/DocumentView.cpp
@@ -492,7 +492,16 @@ bool DocumentView::tryApplyAnchor() {
   // visible" behavior on focus / show events doesn't yank the scroll
   // back to wherever the cursor was previously parked.
   m_browser->setTextCursor(cursor);
-  m_browser->verticalScrollBar()->setValue(int(rect.y()));
+  // blockBoundingRect is in document coordinates, where content starts at
+  // y == documentMargin (the top margin sits above the first block). The
+  // scrollbar value is the document-y shown at the top of the viewport, so a
+  // block lands at the top when value == blockY - documentMargin — the same
+  // relation currentHeadingId() inverts for scroll-spy. Without subtracting the
+  // margin we overshoot by it on every restore; it's only visible at the very
+  // top, where it scrolls the top margin out of view (restoring anchor 0 would
+  // otherwise land at documentMargin instead of 0).
+  const int target = int(rect.y() - doc->documentMargin());
+  m_browser->verticalScrollBar()->setValue(target);
 
   // Do not clear m_pendingAnchor or disconnect here — the timer manages
   // the lifetime of the re-apply window so later layout passes can


### PR DESCRIPTION
Fixes scroll position restoration overshooting by `documentMargin` when applying an anchor.

`blockBoundingRect` returns coordinates in document space, where content begins at `y == documentMargin` due to the top margin above the first block. The scrollbar value represents the document-y position shown at the top of the viewport, so to land a block at the top of the view the margin must be subtracted. Without this correction, every anchor restore overshoots by one margin height, which manifests most visibly at the top of the document where restoring anchor 0 would scroll the top margin out of view instead of landing at position 0.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes scroll-position restoration overshooting by `documentMargin` in `tryApplyAnchor()` by subtracting the document's top margin from the `blockBoundingRect` y-coordinate before passing it to the scrollbar.

- The one-line arithmetic fix (`rect.y() - doc->documentMargin()`) is the exact inverse of the `scrollValue + documentMargin` probe already used in `currentHeadingId()`, so the two code paths are now symmetrically consistent.
- Without the subtraction every anchor restore overshot by `documentMargin`; for anchor 0 this scrolled the top margin out of view instead of landing at position 0.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single arithmetic correction with no side effects and is verified to be the exact inverse of the existing scroll-spy calculation.

The fix is minimal (one line), consistent with the already-correct inverse formula in currentHeadingId(), and handles the edge case (anchor 0) correctly by yielding target == 0. Qt's scrollbar setValue clamps to [minimum, maximum], so any theoretical underflow is safe. No logic paths are removed or altered beyond the scroll target value.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["fix top-scroll drift on restyle"](https://github.com/gesslar/mdv/commit/0e7757a2ef3c3d29b67cdd52c6872c6db7b075e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34489712)</sub>

<!-- /greptile_comment -->