### PR TITLE
add reload/delete buttons to light and dark theme pickers

### DIFF
--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -16,6 +16,7 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QSettings>
+#include <QSizePolicy>
 #include <QSpinBox>
 #include <QToolButton>
 #include <QUrl>
@@ -48,6 +49,29 @@ QToolButton *makeCodiconButton(char16_t glyph, const QString &fallbackText,
 }
 
 }  // namespace
+
+QHBoxLayout *PreferencesDialog::makeThemeRow(QComboBox *combo,
+                                             QToolButton *&refresh,
+                                             QToolButton *&del) {
+  QWidget *parent = combo->parentWidget();
+  refresh = makeCodiconButton(Codicon::Refresh, tr("Reload"),
+                              tr("Reload this theme from disk and re-apply it."),
+                              parent);
+  del = makeCodiconButton(Codicon::Trash, tr("Delete"),
+                          tr("Delete this imported theme."), parent);
+  // Keep the buttons' footprint even while hidden so every combo stays the
+  // same width and the rows line up, bundled or not.
+  for(QToolButton *b : {refresh, del}) {
+    QSizePolicy sp = b->sizePolicy();
+    sp.setRetainSizeWhenHidden(true);
+    b->setSizePolicy(sp);
+  }
+  auto *row = new QHBoxLayout;
+  row->addWidget(combo, /*stretch=*/1);
+  row->addWidget(refresh);
+  row->addWidget(del);
+  return row;
+}
 
 PreferencesDialog::PreferencesDialog(QWidget *parent) : QDialog(parent) {
   setWindowTitle(tr("Preferences"));
@@ -90,17 +114,7 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) : QDialog(parent) {
   auto *singleForm = new QFormLayout(m_singleWidget);
   singleForm->setContentsMargins(0, 0, 0, 0);
   m_themeCombo = new QComboBox(m_singleWidget);
-  m_refreshTheme =
-      makeCodiconButton(Codicon::Refresh, tr("Reload"),
-                        tr("Reload this theme from disk and re-apply it."),
-                        m_singleWidget);
-  m_deleteTheme =
-      makeCodiconButton(Codicon::Trash, tr("Delete"),
-                        tr("Delete this imported theme."), m_singleWidget);
-  auto *singleRow = new QHBoxLayout;
-  singleRow->addWidget(m_themeCombo, /*stretch=*/1);
-  singleRow->addWidget(m_refreshTheme);
-  singleRow->addWidget(m_deleteTheme);
+  auto *singleRow = makeThemeRow(m_themeCombo, m_refreshTheme, m_deleteTheme);
   singleForm->addRow(tr("Content theme:"), singleRow);
   themeOuter->addWidget(m_singleWidget);
 
@@ -111,8 +125,10 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) : QDialog(parent) {
   pairForm->setContentsMargins(0, 0, 0, 0);
   m_lightCombo = new QComboBox(m_pairWidget);
   m_darkCombo = new QComboBox(m_pairWidget);
-  pairForm->addRow(tr("Preferred light:"), m_lightCombo);
-  pairForm->addRow(tr("Preferred dark:"), m_darkCombo);
+  auto *lightRow = makeThemeRow(m_lightCombo, m_lightRefresh, m_lightDelete);
+  auto *darkRow = makeThemeRow(m_darkCombo, m_darkRefresh, m_darkDelete);
+  pairForm->addRow(tr("Preferred light:"), lightRow);
+  pairForm->addRow(tr("Preferred dark:"), darkRow);
   themeOuter->addWidget(m_pairWidget);
 
   root->addWidget(themeGroup);
@@ -121,14 +137,31 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) : QDialog(parent) {
           &PreferencesDialog::updateThemeMode);
   connect(m_themeCombo, &QComboBox::currentIndexChanged, this,
           &PreferencesDialog::updateThemeButtons);
-  connect(m_refreshTheme, &QToolButton::clicked, this,
-          &PreferencesDialog::onRefreshTheme);
+  connect(m_lightCombo, &QComboBox::currentIndexChanged, this,
+          &PreferencesDialog::updateThemeButtons);
+  connect(m_darkCombo, &QComboBox::currentIndexChanged, this,
+          &PreferencesDialog::updateThemeButtons);
+  connect(m_refreshTheme, &QToolButton::clicked, this, [this] {
+    refreshThemeFromCombo(m_themeCombo, QStringLiteral("theme/content"));
+  });
   connect(m_importTheme, &QToolButton::clicked, this,
           &PreferencesDialog::onImportTheme);
   connect(m_deleteTheme, &QToolButton::clicked, this,
           &PreferencesDialog::onDeleteTheme);
   connect(m_openThemesFolder, &QToolButton::clicked, this,
           &PreferencesDialog::onOpenThemesFolder);
+  // Reload and Delete are each scoped to their own combo's selection, so
+  // neither commits a sibling picker's in-flight change behind Cancel's back.
+  connect(m_lightRefresh, &QToolButton::clicked, this, [this] {
+    refreshThemeFromCombo(m_lightCombo, QStringLiteral("theme/light"));
+  });
+  connect(m_darkRefresh, &QToolButton::clicked, this, [this] {
+    refreshThemeFromCombo(m_darkCombo, QStringLiteral("theme/dark"));
+  });
+  connect(m_lightDelete, &QToolButton::clicked, this,
+          [this] { deleteThemeFromCombo(m_lightCombo); });
+  connect(m_darkDelete, &QToolButton::clicked, this,
+          [this] { deleteThemeFromCombo(m_darkCombo); });
 
   // === Fonts ===
   auto *fontsGroup = new QGroupBox(tr("Fonts"), this);
@@ -277,15 +310,23 @@ void PreferencesDialog::populateTypedCombo(QComboBox *combo,
   if(const int idx = combo->findData(selectId); idx >= 0) {
     combo->setCurrentIndex(idx);
   }
+  updateThemeButtons();
 }
 
 void PreferencesDialog::updateThemeButtons() {
   // Refresh and Delete are user-theme affordances: bundled themes live in the
-  // qrc, so they can't be edited in place or removed.
-  const QString id = m_themeCombo->currentData().toString();
-  const bool userTheme = !id.isEmpty() && !ContentTheme::isBundled(id);
-  m_refreshTheme->setVisible(userTheme);
-  m_deleteTheme->setVisible(userTheme);
+  // qrc, so they can't be edited in place or removed. Each combo's pair shows
+  // independently, keyed on that combo's own selection.
+  const auto apply = [](QComboBox *combo, QToolButton *refresh,
+                        QToolButton *del) {
+    const QString id = combo->currentData().toString();
+    const bool userTheme = !id.isEmpty() && !ContentTheme::isBundled(id);
+    refresh->setVisible(userTheme);
+    del->setVisible(userTheme);
+  };
+  apply(m_themeCombo, m_refreshTheme, m_deleteTheme);
+  apply(m_lightCombo, m_lightRefresh, m_lightDelete);
+  apply(m_darkCombo, m_darkRefresh, m_darkDelete);
 }
 
 void PreferencesDialog::updateThemeMode() {
@@ -327,15 +368,17 @@ void PreferencesDialog::onImportTheme() {
                      m_darkCombo->currentData().toString());
 }
 
-void PreferencesDialog::onDeleteTheme() {
-  const QString id = m_themeCombo->currentData().toString();
+void PreferencesDialog::onDeleteTheme() { deleteThemeFromCombo(m_themeCombo); }
+
+void PreferencesDialog::deleteThemeFromCombo(QComboBox *combo) {
+  const QString id = combo->currentData().toString();
   if(id.isEmpty() || ContentTheme::isBundled(id)) return;  // guard
 
   const auto choice = QMessageBox::question(
       this, tr("Delete Theme"),
       tr("Delete the imported theme \"%1\"? This removes the file from your "
          "themes folder.")
-          .arg(m_themeCombo->currentText()));
+          .arg(combo->currentText()));
   if(choice != QMessageBox::Yes) return;
 
   if(!ContentTheme::removeUserTheme(id)) {
@@ -343,21 +386,29 @@ void PreferencesDialog::onDeleteTheme() {
                          tr("Could not delete the theme file."));
     return;
   }
-  // Fall back to the default selection. If the deleted theme was the
-  // persisted choice, ContentTheme::reload() resolves the missing file to
-  // the default on next load, so leaving the setting untouched is safe.
-  populateThemeCombo(QStringLiteral("blackboard"));
+  // Repopulate every picker, preserving each one's current selection. Wherever
+  // the deleted id was selected, findData == -1 falls back to the first entry
+  // (a bundled theme) — and if it was the persisted choice, ContentTheme::
+  // reload() resolves the missing file to the default on next load anyway.
+  populateThemeCombo(m_themeCombo->currentData().toString());
   populateTypedCombo(m_lightCombo, QStringLiteral("light"),
                      m_lightCombo->currentData().toString());
   populateTypedCombo(m_darkCombo, QStringLiteral("dark"),
                      m_darkCombo->currentData().toString());
 }
 
-void PreferencesDialog::onRefreshTheme() {
-  // Persist ONLY the theme selection (not the font/outline widgets, which
-  // would otherwise be committed behind Cancel's back), then re-read it from
-  // disk and re-apply: preferencesApplied() drives the reload + re-render.
-  saveThemeSelection();
+void PreferencesDialog::refreshThemeFromCombo(QComboBox *combo,
+                                              const QString &settingsKey) {
+  // Reload one theme from disk and re-apply it. Persist ONLY this combo's own
+  // key plus followSystem (which decides whether the renderer reads
+  // theme/content or theme/light + theme/dark, and so which picker is even
+  // live). Crucially we do NOT call saveThemeSelection(): writing the sibling
+  // combos would commit their in-flight edits — and the font/outline widgets
+  // are left untouched too — so Cancel still discards everything else.
+  // preferencesApplied() drives the reload + re-render.
+  QSettings s;
+  s.setValue(QStringLiteral("theme/followSystem"), m_followSystem->isChecked());
+  s.setValue(settingsKey, combo->currentData().toString());
   emit preferencesApplied();
 }
 

--- a/src/PreferencesDialog.h
+++ b/src/PreferencesDialog.h
@@ -6,6 +6,7 @@
 class QCheckBox;
 class QComboBox;
 class QFontComboBox;
+class QHBoxLayout;
 class QSpinBox;
 class QToolButton;
 
@@ -40,15 +41,14 @@ private slots:
   void onAccepted();
   void onImportTheme();
   void onDeleteTheme();
-  void onRefreshTheme();
   void onOpenThemesFolder();
 
 private:
   void saveToSettings();
 
   // Persist just the theme selection keys (followSystem + the three theme
-  // ids). Shared by saveToSettings() and onRefreshTheme() — the latter must
-  // NOT commit the font/outline widgets, or Refresh would bypass Cancel.
+  // ids). Used by saveToSettings() on OK/Apply — kept separate so the
+  // theme-only commits don't drag the font/outline widgets along.
   void saveThemeSelection();
 
   // Clear and refill the manual theme combo from ContentTheme::
@@ -62,9 +62,28 @@ private:
   void populateTypedCombo(QComboBox *combo, const QString &type,
                           const QString &selectId);
 
-  // Show the Refresh/Delete buttons only when the manual combo's selection is
-  // a user import (bundled themes are read-only).
+  // Show each combo's Refresh/Delete buttons only when that combo's selection
+  // is a user import (bundled themes are read-only). Covers the manual combo
+  // and both preferred light/dark combos.
   void updateThemeButtons();
+
+  // Confirm and delete the user theme currently selected in <combo>, then
+  // repopulate every picker. No-op for bundled or empty selections. Shared by
+  // the manual, light, and dark delete buttons.
+  void deleteThemeFromCombo(QComboBox *combo);
+
+  // Reload <combo>'s currently-selected theme from disk and re-apply it.
+  // Persists ONLY <settingsKey> (this combo's value) plus followSystem — never
+  // the sibling combos or the font/outline widgets — so a Reload can't commit
+  // another picker's in-flight edit behind Cancel's back. Shared by the
+  // manual, light, and dark Reload buttons.
+  void refreshThemeFromCombo(QComboBox *combo, const QString &settingsKey);
+
+  // Build a "picker row": <combo> followed by per-theme Reload/Delete
+  // codicon buttons, returned via <refresh>/<del> for wiring and visibility.
+  // Reused for the manual combo and both preferred light/dark combos.
+  QHBoxLayout *makeThemeRow(QComboBox *combo, QToolButton *&refresh,
+                            QToolButton *&del);
 
   // Toggle between the manual single-picker and the light/dark pair pickers
   // based on the "follow system" checkbox.
@@ -80,6 +99,10 @@ private:
   QToolButton *m_importTheme = nullptr;
   QToolButton *m_deleteTheme = nullptr;
   QToolButton *m_openThemesFolder = nullptr;
+  QToolButton *m_lightRefresh = nullptr;
+  QToolButton *m_lightDelete = nullptr;
+  QToolButton *m_darkRefresh = nullptr;
+  QToolButton *m_darkDelete = nullptr;
   QFontComboBox *m_proseFont = nullptr;
   QSpinBox *m_proseSize = nullptr;
   QFontComboBox *m_monoFont = nullptr;


### PR DESCRIPTION
Adds Reload and Delete buttons to the preferred light and dark theme pickers, matching the affordances already present on the manual single-theme combo. Previously, users could only reload or delete imported themes when the manual picker was active; the light/dark pair pickers had no such controls.

A `makeThemeRow` helper is introduced to avoid duplicating the button-creation and layout logic across all three rows. Each combo gets its own independent Reload/Delete pair whose visibility is driven by whether that combo's current selection is a user-imported theme. The buttons retain their layout footprint when hidden so all three rows stay the same width regardless of which themes are selected.

`updateThemeButtons` is extended to cover all three combos, and `onDeleteTheme` is refactored into a shared `deleteThemeFromCombo` method that the light and dark delete buttons also call. After a deletion, all three pickers are repopulated while preserving their current selections; any picker that had the deleted theme selected falls back to the first available bundled theme.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the light and dark theme pickers in the Preferences dialog with the same Reload/Delete buttons that the manual single-theme combo already had. A `makeThemeRow` helper is introduced to consolidate button creation and layout across all three rows, and `updateThemeButtons`/`deleteThemeFromCombo`/`refreshThemeFromCombo` are refactored to cover all three combos.

- `makeThemeRow` deduplicates button creation and `RetainSizeWhenHidden` sizing logic, returning a `QHBoxLayout*` for all three picker rows.
- `refreshThemeFromCombo` now persists only `followSystem` + the one combo's key, avoiding the prior bug where the single combo's Reload would silently commit sibling combos' in-flight edits.
- `deleteThemeFromCombo` repopulates all three pickers after removal, falling back to the first bundled entry in any picker that held the deleted ID.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The refactoring is self-contained within the Preferences dialog and the logic correctly scopes each Reload/Delete action to its own combo's key.

The key correctness properties all hold: `refreshThemeFromCombo` persists only the one combo's key and `followSystem`, so clicking Reload on one picker cannot commit a sibling's unsaved selection. `deleteThemeFromCombo` reads each combo's current data before repopulating, so deleted IDs correctly fall back to index 0 via `findData == -1`. All new button pointers are initialized via `makeThemeRow` before `reload()` ever calls `updateThemeButtons()`, ruling out null-dereference at startup. No regressions found.

No files require special attention.

<sub>Reviews (3): Last reviewed commit: ["fixing preferences and theme buttons"](https://github.com/gesslar/mdv/commit/c3046c0c620abcb73036f5ea50d2445e24c27b40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34498958)</sub>

<!-- /greptile_comment -->