### PR TITLE
bump minimum Qt6 requirement to 6.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ set(QT_NO_PRIVATE_MODULE_WARNING ON)
 # integration). We never touch Qt's Vulkan path, so skip the find_package
 # probe — the warning goes away and Qt links exactly the same.
 set(CMAKE_DISABLE_FIND_PACKAGE_WrapVulkanHeaders ON)
-find_package(Qt6 6.5 REQUIRED
+find_package(Qt6 6.11 REQUIRED
     COMPONENTS Widgets CorePrivate GuiPrivate WidgetsPrivate)
 
 # --- Non-Qt dependencies ------------------------------------------------------
@@ -137,7 +137,7 @@ if(WIN32)
     # find_dependency(); on the FetchContent path the consumer (this project)
     # has to declare it. Add it once here so the warning goes away and the
     # link line is honest.
-    find_package(Qt6 6.5 REQUIRED COMPONENTS Network)
+    find_package(Qt6 6.11 REQUIRED COMPONENTS Network)
 
     include(FetchContent)
     set(BUILD_TESTING OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
Bumps the minimum required Qt6 version from 6.5 to 6.11.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the minimum required Qt6 version from 6.5 to 6.11 in two `find_package` calls inside `CMakeLists.txt`. The CMake change itself is correct and consistent, but the Windows CI workflow and developer documentation were not updated alongside it.

- `CMakeLists.txt`: both `find_package(Qt6 6.5 REQUIRED ...)` lines updated to `6.11` — straightforward and internally correct.
- `.github/workflows/release.yml` (unchanged): Windows build step still installs Qt `6.9.0`; CMake will immediately fail at configure time because `6.9.0 < 6.11`.
- `DEVELOPMENT.md` (unchanged): still advertises Qt 6.5+ as the minimum on lines 5, 46, and 64, which will mislead contributors.

<h3>Confidence Score: 4/5</h3>

The CMakeLists.txt change is correct, but the Windows release CI will fail at configure time because it installs Qt 6.9.0 while the build now requires 6.11.

The Windows release workflow installs Qt 6.9.0 but CMakeLists.txt now enforces find_package(Qt6 6.11 REQUIRED). CMake checks the version lower bound at configure time and will error out, breaking the Windows CI job. This needs to be fixed before the next release run.

.github/workflows/release.yml — the version: '6.9.0' in the Windows Qt install step must be bumped to 6.11.x.

<sub>Reviews (4): Last reviewed commit: ["raise qt floor to 6.11"](https://github.com/gesslar/mdv/commit/b27a22c1ba62b2b0505b8588c1bedf065ef6e810) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34504644)</sub>

<!-- /greptile_comment -->