### PR TITLE
derive chrome colors from QPalette and refresh on ApplicationPaletteChange

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,7 @@ qt_add_executable(mdv
     src/WindowsChrome.h
     src/CodiconFont.cpp
     src/CodiconFont.h
+    src/ChromeStyle.h
     src/DocumentView.cpp
     src/DocumentView.h
     src/FindBar.cpp

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- **Qt 6.5 or newer** (Widgets module)
+- **Qt 6.11 or newer** (Widgets module)
 - **md4c** — CommonMark + GFM markdown parser
 - **KSyntaxHighlighting** (KDE Frameworks 6) — code-block syntax highlighting
 - **CMake 3.21 or newer**
@@ -43,7 +43,7 @@ sudo pacman -S qt6-base md4c syntax-highlighting cmake ninja gcc qtcreator
 
 ### macOS
 
-The official **[Qt online installer](https://www.qt.io/download-qt-installer)** is the easiest path. Pick Qt 6.5+ with the Widgets module. Then:
+The official **[Qt online installer](https://www.qt.io/download-qt-installer)** is the easiest path. Pick Qt 6.11+ with the Widgets module. Then:
 
 ```bash
 brew install md4c cmake ninja
@@ -61,7 +61,7 @@ KSyntaxHighlighting (KDE Frameworks 6) isn't in Homebrew core; on macOS install 
 
 ### Windows
 
-Install the official **[Qt online installer](https://www.qt.io/download-qt-installer)** and select Qt 6.5+ with **MinGW 64-bit** (the version this project was developed against; MSVC 2022 64-bit also works). Include **Qt Linguist / qttools** in the install — KSyntaxHighlighting's translation step needs `lrelease` on `PATH`. The Qt installer also bundles CMake, Ninja, and Qt Creator.
+Install the official **[Qt online installer](https://www.qt.io/download-qt-installer)** and select Qt 6.11+ with **MinGW 64-bit** (the version this project was developed against; MSVC 2022 64-bit also works). Include **Qt Linguist / qttools** in the install — KSyntaxHighlighting's translation step needs `lrelease` on `PATH`. The Qt installer also bundles CMake, Ninja, and Qt Creator.
 
 Two extra prereqs that the Qt installer doesn't provide:
 

--- a/src/ChromeStyle.h
+++ b/src/ChromeStyle.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QColor>
+#include <QString>
+
+// Helpers for building palette-derived stylesheets for the window chrome
+// (title bar, outline panel, status bar). The chrome reads its colors from
+// the live QPalette instead of hard-coded hex so it tracks the system theme
+// and accent — and shifts with them at runtime on an ApplicationPaletteChange.
+
+// Format a QColor as a Qt-stylesheet rgba() string with an explicit alpha
+// (0.0-1.0). Used for translucent hover/selection washes layered over a
+// palette color so they read on both light and dark schemes.
+inline QString cssRgba(const QColor &c, qreal alpha) {
+  return QStringLiteral("rgba(%1,%2,%3,%4)")
+      .arg(c.red())
+      .arg(c.green())
+      .arg(c.blue())
+      .arg(alpha, 0, 'f', 3);
+}

--- a/src/DocumentView.cpp
+++ b/src/DocumentView.cpp
@@ -882,8 +882,8 @@ void DocumentView::restyleFindBar() {
   QColor fgc(fg);
   if(!fgc.isValid()) fgc = QColor(0xDD, 0xDD, 0xDD);
   // The find bar is application chrome, not document content, so its accent
-  // follows the system/app palette rather than the markdown theme. (Highlight
-  // is the pre-6.6 equivalent of Accent and a safe fallback.)
+  // follows the system/app palette rather than the markdown theme, with a
+  // defensive Highlight fallback if a platform leaves Accent unset.
   const QPalette pal = m_findBar->palette();
   QColor accent = pal.color(QPalette::Accent);
   if(!accent.isValid()) accent = pal.color(QPalette::Highlight);

--- a/src/EditorGroup.cpp
+++ b/src/EditorGroup.cpp
@@ -29,8 +29,9 @@ namespace {
 
 // Translucent overlay painted on top of a group to preview where a tab
 // drop will land. Mouse-transparent so it never intercepts drag events.
-// Color is sourced from QPalette::Highlight so it tracks the user's
-// system accent / selection color.
+// Color is sourced from QPalette::Accent so it tracks the user's system
+// accent, with a defensive Highlight fallback if a platform leaves Accent
+// unset.
 class DropOverlay : public QWidget {
 public:
   explicit DropOverlay(QWidget *parent) : QWidget(parent) {
@@ -40,7 +41,8 @@ public:
 
 protected:
   void paintEvent(QPaintEvent *) override {
-    const QColor accent = palette().color(QPalette::Highlight);
+    QColor accent = palette().color(QPalette::Accent);
+    if(!accent.isValid()) accent = palette().color(QPalette::Highlight);
     QColor fill = accent;
     fill.setAlpha(80);
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -6,11 +6,13 @@
 #include <QDir>
 #include <QDragEnterEvent>
 #include <QDropEvent>
+#include <QEvent>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QGuiApplication>
 #include <QMenu>
 #include <QMimeData>
+#include <QPalette>
 #include <QProcess>
 #include <QSettings>
 #include <QSignalBlocker>
@@ -20,6 +22,7 @@
 #include <QUrl>
 #include <QVBoxLayout>
 
+#include "ChromeStyle.h"
 #include "ContentTheme.h"
 #include "DocumentView.h"
 #include "EditorArea.h"
@@ -427,26 +430,35 @@ void MainWindow::onMoveTabLeft() {
 }
 
 void MainWindow::refreshStatusBarStyle() {
-  const bool dark =
-      QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
-  const QString fg =
-      dark ? QStringLiteral("#f0f0f0") : QStringLiteral("#000000");
-  // Zero vertical padding so the button hugs the text height and the status
-  // bar centers it; horizontal padding gives the hover pill some breathing
-  // room while keeping the small left inset off the window edge. Hover/press
-  // use a grey wash that reads on either scheme.
+  // Colors track the system palette: WindowText for the label/button, the
+  // palette's disabled WindowText for the dimmed state, and translucent
+  // WindowText washes for hover/press (which read on any scheme). Zero
+  // vertical padding lets the status bar center the button to text height;
+  // horizontal padding gives the hover pill room while keeping a small inset.
+  const QPalette pal = palette();
+  const QColor txt = pal.color(QPalette::WindowText);
+  const QString fg = txt.name();
+  const QString dis =
+      pal.color(QPalette::Disabled, QPalette::WindowText).name();
+  const QString hover = cssRgba(txt, 0.18);
+  const QString press = cssRgba(txt, 0.30);
   statusBar()->setStyleSheet(
       QStringLiteral(
           "QStatusBar { color: %1; }"
           "QStatusBar::item { border: none; }"
           "QStatusBar QToolButton { border: none; background: transparent;"
           " color: %1; padding: 0px 8px 0px 4px; border-radius: 4px; }"
-          "QStatusBar QToolButton:disabled { color: #888888; }"
-          "QStatusBar QToolButton:enabled:hover { background: "
-          "rgba(127,127,127,0.18); }"
-          "QStatusBar QToolButton:enabled:pressed { background: "
-          "rgba(127,127,127,0.30); }")
-          .arg(fg));
+          "QStatusBar QToolButton:disabled { color: %2; }"
+          "QStatusBar QToolButton:enabled:hover { background: %3; }"
+          "QStatusBar QToolButton:enabled:pressed { background: %4; }")
+          .arg(fg, dis, hover, press));
+}
+
+void MainWindow::changeEvent(QEvent *e) {
+  QMainWindow::changeEvent(e);
+  // ApplicationPaletteChange covers both accent and light/dark shifts; the
+  // explicit stylesheet would otherwise stay frozen at its old colors.
+  if(e->type() == QEvent::ApplicationPaletteChange) refreshStatusBarStyle();
 }
 
 void MainWindow::onCurrentDocumentChanged(DocumentView *doc) {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -25,6 +25,9 @@ public:
 protected:
   void dragEnterEvent(QDragEnterEvent *e) override;
   void dropEvent(QDropEvent *e) override;
+  // Re-pull the status bar stylesheet when the system palette shifts (accent
+  // or light/dark), so it keeps belonging to the desktop around it.
+  void changeEvent(QEvent *e) override;
 
 private slots:
   void onOpen();

--- a/src/OutlinePanel.cpp
+++ b/src/OutlinePanel.cpp
@@ -1,24 +1,21 @@
 #include "OutlinePanel.h"
 
 #include <QAbstractItemView>
+#include <QEvent>
 #include <QFont>
 #include <QGuiApplication>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMenu>
+#include <QPalette>
 #include <QStyleHints>
 #include <QToolButton>
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 #include <QVBoxLayout>
 
+#include "ChromeStyle.h"
 #include "CodiconFont.h"
-
-namespace {
-bool isDark() {
-  return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
-}
-}  // namespace
 
 OutlinePanel::OutlinePanel(QWidget *parent) : QWidget(parent) {
   setObjectName(QStringLiteral("OutlinePanel"));
@@ -148,17 +145,21 @@ void OutlinePanel::setCurrentHeading(const QString &anchorId) {
 }
 
 void OutlinePanel::refreshTheme() {
-  const bool dark = isDark();
-  const QString bg =
-      dark ? QStringLiteral("#1f1f1f") : QStringLiteral("#f3f3f3");
-  const QString fg =
-      dark ? QStringLiteral("#e8e8e8") : QStringLiteral("#1a1a1a");
-  const QString muted =
-      dark ? QStringLiteral("#9d9d9d") : QStringLiteral("#6e6e6e");
-  const QString hover = dark ? QStringLiteral("rgba(255,255,255,0.07)")
-                             : QStringLiteral("rgba(0,0,0,0.05)");
-  const QString sel = dark ? QStringLiteral("rgba(255,255,255,0.12)")
-                           : QStringLiteral("rgba(0,0,0,0.10)");
+  // All colors come from the system palette so the panel matches the rest of
+  // the chrome and follows accent/scheme changes: Window/WindowText for the
+  // surface and rows, PlaceholderText for the muted title/placeholder, a
+  // translucent WindowText wash for hover, and the real Highlight/
+  // HighlightedText pair for the selected row so selection tracks the accent.
+  const QPalette pal = palette();
+  const QColor txt = pal.color(QPalette::WindowText);
+  const QColor place = pal.color(QPalette::PlaceholderText);
+  const QString bg = pal.color(QPalette::Window).name();
+  const QString fg = txt.name();
+  const QString muted = cssRgba(place, place.alphaF());
+  const QString hover = cssRgba(txt, 0.07);
+  // Selection is a 50%-alpha accent tint, not a solid fill — so the row stays
+  // softer and normal WindowText reads better on it than HighlightedText.
+  const QString sel = cssRgba(pal.color(QPalette::Highlight), 0.5);
 
   setStyleSheet(QStringLiteral(R"(
 OutlinePanel, #outlineHeader { background: %1; }
@@ -176,4 +177,11 @@ QTreeWidget#outlineTree::item:hover { background: %4; }
 QTreeWidget#outlineTree::item:selected { background: %5; color: %2; }
 )")
                     .arg(bg, fg, muted, hover, sel));
+}
+
+void OutlinePanel::changeEvent(QEvent *e) {
+  QWidget::changeEvent(e);
+  // ApplicationPaletteChange covers both accent and light/dark shifts; the
+  // explicit stylesheet would otherwise stay frozen at its old colors.
+  if(e->type() == QEvent::ApplicationPaletteChange) refreshTheme();
 }

--- a/src/OutlinePanel.h
+++ b/src/OutlinePanel.h
@@ -40,6 +40,11 @@ signals:
   void hideRequested();
   void moveToOtherSideRequested();
 
+protected:
+  // Re-pull the stylesheet when the system palette shifts (accent or
+  // light/dark), so the panel keeps matching the surrounding chrome.
+  void changeEvent(QEvent *e) override;
+
 private:
   void refreshTheme();
 

--- a/src/TitleBar.cpp
+++ b/src/TitleBar.cpp
@@ -6,10 +6,12 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMenu>
+#include <QPalette>
 #include <QStyle>
 #include <QStyleHints>
 #include <QToolButton>
 
+#include "ChromeStyle.h"
 #include "CodiconFont.h"
 
 namespace {
@@ -101,20 +103,17 @@ TitleBar::TitleBar(QWidget *parent) : QWidget(parent) {
 }
 
 void TitleBar::refreshTheme() {
-  // Title bar tracks the active Qt color scheme so it doesn't fight the rest
-  // of the chrome on a system-theme switch. Close button hover stays the
-  // canonical Win11 red regardless of scheme; the menu-indicator chevron is
-  // suppressed in both — the buttons read as labels, not dropdowns.
-  const bool dark =
-      QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
-  const QString bg =
-      dark ? QStringLiteral("#1f1f1f") : QStringLiteral("#f3f3f3");
-  const QString fg =
-      dark ? QStringLiteral("#f0f0f0") : QStringLiteral("#000000");
-  const QString hover = dark ? QStringLiteral("rgba(255,255,255,0.08)")
-                             : QStringLiteral("rgba(0,0,0,0.06)");
-  const QString press = dark ? QStringLiteral("rgba(255,255,255,0.04)")
-                             : QStringLiteral("rgba(0,0,0,0.04)");
+  // Title bar colors come straight from the system palette so it belongs to
+  // the desktop and shifts with it — Window/WindowText for the surface, with
+  // hover/press as translucent WindowText washes that read on any scheme.
+  // Close button hover stays the canonical Win11 red regardless of scheme; the
+  // menu-indicator chevron is suppressed so the buttons read as labels.
+  const QPalette pal = palette();
+  const QString bg = pal.color(QPalette::Window).name();
+  const QString fg = pal.color(QPalette::WindowText).name();
+  const QColor txt = pal.color(QPalette::WindowText);
+  const QString hover = cssRgba(txt, 0.10);
+  const QString press = cssRgba(txt, 0.16);
 
   setStyleSheet(QStringLiteral(R"(
 TitleBar { background: %1; }
@@ -131,6 +130,13 @@ TitleBar QToolButton#sysClose:pressed { background: #b4271a; color: white; }
 TitleBar QToolButton::menu-indicator { image: none; }
 )")
                     .arg(bg, fg, hover, press));
+}
+
+void TitleBar::changeEvent(QEvent *e) {
+  QWidget::changeEvent(e);
+  // ApplicationPaletteChange covers both accent and light/dark shifts; the
+  // explicit stylesheet would otherwise stay frozen at its old colors.
+  if(e->type() == QEvent::ApplicationPaletteChange) refreshTheme();
 }
 
 void TitleBar::setFileMenu(QMenu *menu) { m_fileBtn->setMenu(menu); }

--- a/src/TitleBar.h
+++ b/src/TitleBar.h
@@ -36,6 +36,9 @@ signals:
 protected:
   bool eventFilter(QObject *obj, QEvent *e) override;
   void showEvent(QShowEvent *e) override;
+  // Re-pull the stylesheet when the system palette shifts (accent or
+  // light/dark), so the bar keeps belonging to the desktop around it.
+  void changeEvent(QEvent *e) override;
 
 private:
   void refreshMaxIcon();


### PR DESCRIPTION
All chrome components (title bar, outline panel, status bar) previously used hard-coded hex color values chosen by inspecting the active color scheme at stylesheet-build time. This meant colors were frozen at construction and would not update if the system theme or accent color changed at runtime.

This replaces all hard-coded hex colors with values derived from the live `QPalette`. `Window`/`WindowText` drive surface and text colors, `PlaceholderText` drives muted labels, and `Highlight` drives selection. Hover and press states are expressed as translucent `WindowText` washes via a new `cssRgba` helper (introduced in `ChromeStyle.h`) so they remain legible on any scheme without separate light/dark branches.

Each chrome widget now overrides `changeEvent` and calls its `refreshTheme`/`refreshStatusBarStyle` method on `QEvent::ApplicationPaletteChange`, so stylesheets are rebuilt whenever the system accent or light/dark scheme shifts at runtime.

`DropOverlay` in `EditorGroup` is updated similarly to prefer `QPalette::Accent` for its fill color, falling back to `QPalette::Highlight` on Qt versions prior to 6.6 where `Accent` is not available.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces all hard-coded hex color values in the chrome widgets (`TitleBar`, `OutlinePanel`, `MainWindow` status bar) with live `QPalette` reads, and adds `changeEvent` overrides on each widget so stylesheets are rebuilt when `QEvent::ApplicationPaletteChange` fires. A new `ChromeStyle.h` header provides the shared `cssRgba` helper for generating translucent washes.

- `TitleBar`, `OutlinePanel`, and `MainWindow` now derive `Window`/`WindowText`/`PlaceholderText`/`Highlight` from the live palette and override `changeEvent` to refresh on `ApplicationPaletteChange`, covering both accent and light/dark shifts.
- `DropOverlay` in `EditorGroup` is updated to prefer `QPalette::Accent` (with `Highlight` as fallback), consistent with the PR's intent to use the canonical accent role.
- The DEVELOPMENT.md minimum Qt version is bumped to 6.11, matching the existing `find_package(Qt6 6.11 ...)` constraint in `CMakeLists.txt`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changes are additive stylesheet migrations with no behavioral regressions.

All chrome widgets correctly read from the live palette and re-apply their stylesheets on palette changes. The only finding is a minor redundancy: the pre-existing colorSchemeChanged connections in the TitleBar and OutlinePanel constructors now overlap with the new ApplicationPaletteChange handlers, causing refreshTheme() to be called twice on light/dark scheme transitions. This is entirely harmless since Qt skips repaint when the stylesheet string is unchanged.

No files require special attention.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2FTitleBar.cpp%3A135-140%0A**Redundant%20double-refresh%20on%20color-scheme%20changes**%0A%0AThe%20constructor%20of%20%60TitleBar%60%20%28and%20similarly%20%60OutlinePanel%60%29%20still%20connects%20%60QStyleHints%3A%3AcolorSchemeChanged%60%20to%20call%20%60refreshTheme%28%29%60.%20With%20the%20new%20%60changeEvent%60%20override%20added%20here%2C%20a%20light%2Fdark%20scheme%20flip%20will%20dispatch%20%60QEvent%3A%3AApplicationPaletteChange%60%20and%20call%20%60refreshTheme%28%29%60%20a%20second%20time%20in%20the%20same%20event%20loop%20turn%2C%20because%20a%20scheme%20change%20always%20triggers%20a%20palette%20update.%20The%20extra%20call%20is%20harmless%20%28Qt%20will%20skip%20the%20repaint%20if%20the%20stylesheet%20string%20is%20unchanged%29%2C%20but%20the%20%60colorSchemeChanged%60%20connections%20in%20both%20constructors%20are%20now%20redundant%20for%20pure%20styling%20purposes%20and%20can%20be%20removed.%20The%20same%20double-call%20pattern%20is%20present%20in%20%60OutlinePanel.cpp%60.%0A%0A&repo=gesslar%2Fmdv&pr=38&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (4): Last reviewed commit: ["system palette for window chrome"](https://github.com/gesslar/mdv/commit/4241b2b5a72029f174fac3c9d0fecad685238138) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34504649)</sub>

<!-- /greptile_comment -->