### PR TITLE
05 28 bump

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.21)
 
 project(mdv
-    VERSION 2.3.1
+    VERSION 2.4.0
     DESCRIPTION "An offline Markdown viewer for everybody! For free! Huzzah!"
     LANGUAGES CXX
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,7 @@ qt_add_executable(mdv
     src/WindowsChrome.h
     src/CodiconFont.cpp
     src/CodiconFont.h
+    src/ChromeStyle.h
     src/DocumentView.cpp
     src/DocumentView.h
     src/FindBar.cpp

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- **Qt 6.5 or newer** (Widgets module)
+- **Qt 6.11 or newer** (Widgets module)
 - **md4c** — CommonMark + GFM markdown parser
 - **KSyntaxHighlighting** (KDE Frameworks 6) — code-block syntax highlighting
 - **CMake 3.21 or newer**
@@ -43,7 +43,7 @@ sudo pacman -S qt6-base md4c syntax-highlighting cmake ninja gcc qtcreator
 
 ### macOS
 
-The official **[Qt online installer](https://www.qt.io/download-qt-installer)** is the easiest path. Pick Qt 6.5+ with the Widgets module. Then:
+The official **[Qt online installer](https://www.qt.io/download-qt-installer)** is the easiest path. Pick Qt 6.11+ with the Widgets module. Then:
 
 ```bash
 brew install md4c cmake ninja
@@ -61,7 +61,7 @@ KSyntaxHighlighting (KDE Frameworks 6) isn't in Homebrew core; on macOS install 
 
 ### Windows
 
-Install the official **[Qt online installer](https://www.qt.io/download-qt-installer)** and select Qt 6.5+ with **MinGW 64-bit** (the version this project was developed against; MSVC 2022 64-bit also works). Include **Qt Linguist / qttools** in the install — KSyntaxHighlighting's translation step needs `lrelease` on `PATH`. The Qt installer also bundles CMake, Ninja, and Qt Creator.
+Install the official **[Qt online installer](https://www.qt.io/download-qt-installer)** and select Qt 6.11+ with **MinGW 64-bit** (the version this project was developed against; MSVC 2022 64-bit also works). Include **Qt Linguist / qttools** in the install — KSyntaxHighlighting's translation step needs `lrelease` on `PATH`. The Qt installer also bundles CMake, Ninja, and Qt Creator.
 
 Two extra prereqs that the Qt installer doesn't provide:
 

--- a/src/ChromeStyle.h
+++ b/src/ChromeStyle.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QColor>
+#include <QString>
+
+// Helpers for building palette-derived stylesheets for the window chrome
+// (title bar, outline panel, status bar). The chrome reads its colors from
+// the live QPalette instead of hard-coded hex so it tracks the system theme
+// and accent — and shifts with them at runtime on an ApplicationPaletteChange.
+
+// Format a QColor as a Qt-stylesheet rgba() string with an explicit alpha
+// (0.0-1.0). Used for translucent hover/selection washes layered over a
+// palette color so they read on both light and dark schemes.
+inline QString cssRgba(const QColor &c, qreal alpha) {
+  return QStringLiteral("rgba(%1,%2,%3,%4)")
+      .arg(c.red())
+      .arg(c.green())
+      .arg(c.blue())
+      .arg(alpha, 0, 'f', 3);
+}

--- a/src/DocumentView.cpp
+++ b/src/DocumentView.cpp
@@ -882,8 +882,8 @@ void DocumentView::restyleFindBar() {
   QColor fgc(fg);
   if(!fgc.isValid()) fgc = QColor(0xDD, 0xDD, 0xDD);
   // The find bar is application chrome, not document content, so its accent
-  // follows the system/app palette rather than the markdown theme. (Highlight
-  // is the pre-6.6 equivalent of Accent and a safe fallback.)
+  // follows the system/app palette rather than the markdown theme, with a
+  // defensive Highlight fallback if a platform leaves Accent unset.
   const QPalette pal = m_findBar->palette();
   QColor accent = pal.color(QPalette::Accent);
   if(!accent.isValid()) accent = pal.color(QPalette::Highlight);

--- a/src/EditorGroup.cpp
+++ b/src/EditorGroup.cpp
@@ -29,8 +29,9 @@ namespace {
 
 // Translucent overlay painted on top of a group to preview where a tab
 // drop will land. Mouse-transparent so it never intercepts drag events.
-// Color is sourced from QPalette::Highlight so it tracks the user's
-// system accent / selection color.
+// Color is sourced from QPalette::Accent so it tracks the user's system
+// accent, with a defensive Highlight fallback if a platform leaves Accent
+// unset.
 class DropOverlay : public QWidget {
 public:
   explicit DropOverlay(QWidget *parent) : QWidget(parent) {
@@ -40,7 +41,8 @@ public:
 
 protected:
   void paintEvent(QPaintEvent *) override {
-    const QColor accent = palette().color(QPalette::Highlight);
+    QColor accent = palette().color(QPalette::Accent);
+    if(!accent.isValid()) accent = palette().color(QPalette::Highlight);
     QColor fill = accent;
     fill.setAlpha(80);
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -6,11 +6,13 @@
 #include <QDir>
 #include <QDragEnterEvent>
 #include <QDropEvent>
+#include <QEvent>
 #include <QFileDialog>
 #include <QFileInfo>
 #include <QGuiApplication>
 #include <QMenu>
 #include <QMimeData>
+#include <QPalette>
 #include <QProcess>
 #include <QSettings>
 #include <QSignalBlocker>
@@ -20,6 +22,7 @@
 #include <QUrl>
 #include <QVBoxLayout>
 
+#include "ChromeStyle.h"
 #include "ContentTheme.h"
 #include "DocumentView.h"
 #include "EditorArea.h"
@@ -427,26 +430,35 @@ void MainWindow::onMoveTabLeft() {
 }
 
 void MainWindow::refreshStatusBarStyle() {
-  const bool dark =
-      QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
-  const QString fg =
-      dark ? QStringLiteral("#f0f0f0") : QStringLiteral("#000000");
-  // Zero vertical padding so the button hugs the text height and the status
-  // bar centers it; horizontal padding gives the hover pill some breathing
-  // room while keeping the small left inset off the window edge. Hover/press
-  // use a grey wash that reads on either scheme.
+  // Colors track the system palette: WindowText for the label/button, the
+  // palette's disabled WindowText for the dimmed state, and translucent
+  // WindowText washes for hover/press (which read on any scheme). Zero
+  // vertical padding lets the status bar center the button to text height;
+  // horizontal padding gives the hover pill room while keeping a small inset.
+  const QPalette pal = palette();
+  const QColor txt = pal.color(QPalette::WindowText);
+  const QString fg = txt.name();
+  const QString dis =
+      pal.color(QPalette::Disabled, QPalette::WindowText).name();
+  const QString hover = cssRgba(txt, 0.18);
+  const QString press = cssRgba(txt, 0.30);
   statusBar()->setStyleSheet(
       QStringLiteral(
           "QStatusBar { color: %1; }"
           "QStatusBar::item { border: none; }"
           "QStatusBar QToolButton { border: none; background: transparent;"
           " color: %1; padding: 0px 8px 0px 4px; border-radius: 4px; }"
-          "QStatusBar QToolButton:disabled { color: #888888; }"
-          "QStatusBar QToolButton:enabled:hover { background: "
-          "rgba(127,127,127,0.18); }"
-          "QStatusBar QToolButton:enabled:pressed { background: "
-          "rgba(127,127,127,0.30); }")
-          .arg(fg));
+          "QStatusBar QToolButton:disabled { color: %2; }"
+          "QStatusBar QToolButton:enabled:hover { background: %3; }"
+          "QStatusBar QToolButton:enabled:pressed { background: %4; }")
+          .arg(fg, dis, hover, press));
+}
+
+void MainWindow::changeEvent(QEvent *e) {
+  QMainWindow::changeEvent(e);
+  // ApplicationPaletteChange covers both accent and light/dark shifts; the
+  // explicit stylesheet would otherwise stay frozen at its old colors.
+  if(e->type() == QEvent::ApplicationPaletteChange) refreshStatusBarStyle();
 }
 
 void MainWindow::onCurrentDocumentChanged(DocumentView *doc) {

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -25,6 +25,9 @@ public:
 protected:
   void dragEnterEvent(QDragEnterEvent *e) override;
   void dropEvent(QDropEvent *e) override;
+  // Re-pull the status bar stylesheet when the system palette shifts (accent
+  // or light/dark), so it keeps belonging to the desktop around it.
+  void changeEvent(QEvent *e) override;
 
 private slots:
   void onOpen();

--- a/src/OutlinePanel.cpp
+++ b/src/OutlinePanel.cpp
@@ -1,24 +1,21 @@
 #include "OutlinePanel.h"
 
 #include <QAbstractItemView>
+#include <QEvent>
 #include <QFont>
 #include <QGuiApplication>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMenu>
+#include <QPalette>
 #include <QStyleHints>
 #include <QToolButton>
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 #include <QVBoxLayout>
 
+#include "ChromeStyle.h"
 #include "CodiconFont.h"
-
-namespace {
-bool isDark() {
-  return QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
-}
-}  // namespace
 
 OutlinePanel::OutlinePanel(QWidget *parent) : QWidget(parent) {
   setObjectName(QStringLiteral("OutlinePanel"));
@@ -148,17 +145,21 @@ void OutlinePanel::setCurrentHeading(const QString &anchorId) {
 }
 
 void OutlinePanel::refreshTheme() {
-  const bool dark = isDark();
-  const QString bg =
-      dark ? QStringLiteral("#1f1f1f") : QStringLiteral("#f3f3f3");
-  const QString fg =
-      dark ? QStringLiteral("#e8e8e8") : QStringLiteral("#1a1a1a");
-  const QString muted =
-      dark ? QStringLiteral("#9d9d9d") : QStringLiteral("#6e6e6e");
-  const QString hover = dark ? QStringLiteral("rgba(255,255,255,0.07)")
-                             : QStringLiteral("rgba(0,0,0,0.05)");
-  const QString sel = dark ? QStringLiteral("rgba(255,255,255,0.12)")
-                           : QStringLiteral("rgba(0,0,0,0.10)");
+  // All colors come from the system palette so the panel matches the rest of
+  // the chrome and follows accent/scheme changes: Window/WindowText for the
+  // surface and rows, PlaceholderText for the muted title/placeholder, a
+  // translucent WindowText wash for hover, and the real Highlight/
+  // HighlightedText pair for the selected row so selection tracks the accent.
+  const QPalette pal = palette();
+  const QColor txt = pal.color(QPalette::WindowText);
+  const QColor place = pal.color(QPalette::PlaceholderText);
+  const QString bg = pal.color(QPalette::Window).name();
+  const QString fg = txt.name();
+  const QString muted = cssRgba(place, place.alphaF());
+  const QString hover = cssRgba(txt, 0.07);
+  // Selection is a 50%-alpha accent tint, not a solid fill — so the row stays
+  // softer and normal WindowText reads better on it than HighlightedText.
+  const QString sel = cssRgba(pal.color(QPalette::Highlight), 0.5);
 
   setStyleSheet(QStringLiteral(R"(
 OutlinePanel, #outlineHeader { background: %1; }
@@ -176,4 +177,11 @@ QTreeWidget#outlineTree::item:hover { background: %4; }
 QTreeWidget#outlineTree::item:selected { background: %5; color: %2; }
 )")
                     .arg(bg, fg, muted, hover, sel));
+}
+
+void OutlinePanel::changeEvent(QEvent *e) {
+  QWidget::changeEvent(e);
+  // ApplicationPaletteChange covers both accent and light/dark shifts; the
+  // explicit stylesheet would otherwise stay frozen at its old colors.
+  if(e->type() == QEvent::ApplicationPaletteChange) refreshTheme();
 }

--- a/src/OutlinePanel.h
+++ b/src/OutlinePanel.h
@@ -40,6 +40,11 @@ signals:
   void hideRequested();
   void moveToOtherSideRequested();
 
+protected:
+  // Re-pull the stylesheet when the system palette shifts (accent or
+  // light/dark), so the panel keeps matching the surrounding chrome.
+  void changeEvent(QEvent *e) override;
+
 private:
   void refreshTheme();
 

--- a/src/TitleBar.cpp
+++ b/src/TitleBar.cpp
@@ -6,10 +6,12 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QMenu>
+#include <QPalette>
 #include <QStyle>
 #include <QStyleHints>
 #include <QToolButton>
 
+#include "ChromeStyle.h"
 #include "CodiconFont.h"
 
 namespace {
@@ -101,20 +103,17 @@ TitleBar::TitleBar(QWidget *parent) : QWidget(parent) {
 }
 
 void TitleBar::refreshTheme() {
-  // Title bar tracks the active Qt color scheme so it doesn't fight the rest
-  // of the chrome on a system-theme switch. Close button hover stays the
-  // canonical Win11 red regardless of scheme; the menu-indicator chevron is
-  // suppressed in both — the buttons read as labels, not dropdowns.
-  const bool dark =
-      QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark;
-  const QString bg =
-      dark ? QStringLiteral("#1f1f1f") : QStringLiteral("#f3f3f3");
-  const QString fg =
-      dark ? QStringLiteral("#f0f0f0") : QStringLiteral("#000000");
-  const QString hover = dark ? QStringLiteral("rgba(255,255,255,0.08)")
-                             : QStringLiteral("rgba(0,0,0,0.06)");
-  const QString press = dark ? QStringLiteral("rgba(255,255,255,0.04)")
-                             : QStringLiteral("rgba(0,0,0,0.04)");
+  // Title bar colors come straight from the system palette so it belongs to
+  // the desktop and shifts with it — Window/WindowText for the surface, with
+  // hover/press as translucent WindowText washes that read on any scheme.
+  // Close button hover stays the canonical Win11 red regardless of scheme; the
+  // menu-indicator chevron is suppressed so the buttons read as labels.
+  const QPalette pal = palette();
+  const QString bg = pal.color(QPalette::Window).name();
+  const QString fg = pal.color(QPalette::WindowText).name();
+  const QColor txt = pal.color(QPalette::WindowText);
+  const QString hover = cssRgba(txt, 0.10);
+  const QString press = cssRgba(txt, 0.16);
 
   setStyleSheet(QStringLiteral(R"(
 TitleBar { background: %1; }
@@ -131,6 +130,13 @@ TitleBar QToolButton#sysClose:pressed { background: #b4271a; color: white; }
 TitleBar QToolButton::menu-indicator { image: none; }
 )")
                     .arg(bg, fg, hover, press));
+}
+
+void TitleBar::changeEvent(QEvent *e) {
+  QWidget::changeEvent(e);
+  // ApplicationPaletteChange covers both accent and light/dark shifts; the
+  // explicit stylesheet would otherwise stay frozen at its old colors.
+  if(e->type() == QEvent::ApplicationPaletteChange) refreshTheme();
 }
 
 void TitleBar::setFileMenu(QMenu *menu) { m_fileBtn->setMenu(menu); }

--- a/src/TitleBar.h
+++ b/src/TitleBar.h
@@ -36,6 +36,9 @@ signals:
 protected:
   bool eventFilter(QObject *obj, QEvent *e) override;
   void showEvent(QShowEvent *e) override;
+  // Re-pull the stylesheet when the system palette shifts (accent or
+  // light/dark), so the bar keeps belonging to the desktop around it.
+  void changeEvent(QEvent *e) override;
 
 private:
   void refreshMaxIcon();


### PR DESCRIPTION
- **system palette for window chrome**
- **bump**

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces hard-coded dark/light hex colour constants in the window chrome (title bar, outline panel, status bar) with live `QPalette` lookups, and adds `changeEvent` overrides on each widget to re-apply the stylesheet whenever the system palette changes. The minimum Qt requirement is bumped from 6.5 to 6.11 to match the newly used `QPalette::Accent` API (introduced in 6.6).

- **ChromeStyle.h** introduces `cssRgba`, an inline helper that formats a `QColor` and an explicit alpha into a CSS `rgba()` string, used across all three chrome components for translucent hover/press washes.
- **TitleBar**, **OutlinePanel**, and **MainWindow** each replace `isDark()` / fixed hex strings with `palette().color(...)` lookups and gain a `changeEvent` override that calls `refreshTheme()` / `refreshStatusBarStyle()` on `QEvent::ApplicationPaletteChange`.
- **EditorGroup**'s `DropOverlay` switches from `QPalette::Highlight` to `QPalette::Accent` (with `Highlight` as fallback) for the drop-target tint, consistent with the rest of the chrome.

<h3>Confidence Score: 5/5</h3>

Straightforward palette-based refactor with no logic changes to document rendering or file handling; safe to merge.

All three chrome components consistently apply the same changeEvent → refreshTheme() pattern, the cssRgba helper is correctly implemented, the QPalette::Accent / Highlight fallback is guarded, and the Qt minimum version bump to 6.11 covers the newly required API surface. No pre-existing commented-out code was introduced or left in a broken state.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["bump"](https://github.com/gesslar/mdv/commit/358a8424c2e908bea6a7e1ae305c8ad291745d35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34509400)</sub>

<!-- /greptile_comment -->