### PR TITLE
lower minimum Qt6 requirement to 6.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,13 +102,15 @@ jobs:
       # Qt 6 + a matching MinGW (the toolchain DEVELOPMENT.md targets first).
       # `cache: true` keeps the ~2 GB Qt download out of the critical path on
       # subsequent runs.
-      # Qt 6.9.0 is the minimum KSyntaxHighlighting v6.26 (what CMakeLists
-      # fetches in-tree on Windows) accepts — see _deps/ksyntaxhighlighting-src
-      # CMakeLists.txt :42, which calls find_package(Qt6 6.9.0 ...).
+      # Install 6.10 to match the project's CMake floor. KSyntaxHighlighting
+      # v6.26 (fetched in-tree on Windows) only needs >= 6.9.0 — see
+      # _deps/ksyntaxhighlighting-src CMakeLists.txt :42 — so 6.10 clears it.
+      # 6.11 isn't an option matrix-wide: the Flatpak job's KDE runtime
+      # (org.kde.Platform) tops out at 6.10 on Flathub.
       - name: Install Qt 6 + MinGW
         uses: jurplel/install-qt-action@v4
         with:
-          version: '6.9.0'
+          version: '6.10.0'
           host: windows
           target: desktop
           arch: win64_mingw
@@ -154,7 +156,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Only the flatpak entry pulls org.kde.Platform/Sdk 6.9 (~1.5 GB);
+      # Only the flatpak entry pulls org.kde.Platform/Sdk 6.10 (~1.5 GB);
       # docker/dist.sh stores it under ~/.cache/mdv-flatpak. The other three
       # formats don't touch the KDE runtime at all, so the cache step is gated
       # on matrix.format to avoid a useless save/restore on those entries.
@@ -163,7 +165,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/mdv-flatpak
-          key: mdv-flatpak-kde-6.9-${{ runner.os }}
+          key: mdv-flatpak-kde-6.10-${{ runner.os }}
 
       # Each matrix entry builds its own format inside the pinned Fedora
       # container. Runners are independent, so the four run in parallel —

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ set(QT_NO_PRIVATE_MODULE_WARNING ON)
 # integration). We never touch Qt's Vulkan path, so skip the find_package
 # probe — the warning goes away and Qt links exactly the same.
 set(CMAKE_DISABLE_FIND_PACKAGE_WrapVulkanHeaders ON)
-find_package(Qt6 6.11 REQUIRED
+find_package(Qt6 6.10 REQUIRED
     COMPONENTS Widgets CorePrivate GuiPrivate WidgetsPrivate)
 
 # --- Non-Qt dependencies ------------------------------------------------------
@@ -137,7 +137,7 @@ if(WIN32)
     # find_dependency(); on the FetchContent path the consumer (this project)
     # has to declare it. Add it once here so the warning goes away and the
     # link line is honest.
-    find_package(Qt6 6.11 REQUIRED COMPONENTS Network)
+    find_package(Qt6 6.10 REQUIRED COMPONENTS Network)
 
     include(FetchContent)
     set(BUILD_TESTING OFF CACHE BOOL "" FORCE)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- **Qt 6.11 or newer** (Widgets module)
+- **Qt 6.10 or newer** (Widgets module)
 - **md4c** — CommonMark + GFM markdown parser
 - **KSyntaxHighlighting** (KDE Frameworks 6) — code-block syntax highlighting
 - **CMake 3.21 or newer**
@@ -43,7 +43,7 @@ sudo pacman -S qt6-base md4c syntax-highlighting cmake ninja gcc qtcreator
 
 ### macOS
 
-The official **[Qt online installer](https://www.qt.io/download-qt-installer)** is the easiest path. Pick Qt 6.11+ with the Widgets module. Then:
+The official **[Qt online installer](https://www.qt.io/download-qt-installer)** is the easiest path. Pick Qt 6.10+ with the Widgets module. Then:
 
 ```bash
 brew install md4c cmake ninja
@@ -61,7 +61,7 @@ KSyntaxHighlighting (KDE Frameworks 6) isn't in Homebrew core; on macOS install 
 
 ### Windows
 
-Install the official **[Qt online installer](https://www.qt.io/download-qt-installer)** and select Qt 6.11+ with **MinGW 64-bit** (the version this project was developed against; MSVC 2022 64-bit also works). Include **Qt Linguist / qttools** in the install — KSyntaxHighlighting's translation step needs `lrelease` on `PATH`. The Qt installer also bundles CMake, Ninja, and Qt Creator.
+Install the official **[Qt online installer](https://www.qt.io/download-qt-installer)** and select Qt 6.10+ with **MinGW 64-bit** (the version this project was developed against; MSVC 2022 64-bit also works). Include **Qt Linguist / qttools** in the install — KSyntaxHighlighting's translation step needs `lrelease` on `PATH`. The Qt installer also bundles CMake, Ninja, and Qt Creator.
 
 Two extra prereqs that the Qt installer doesn't provide:
 
@@ -135,7 +135,7 @@ the link line if you add a library. RPM `Requires:` are auto-detected by
 ### Flatpak
 
 A single-file `.flatpak` is built with `flatpak-builder` against the KDE runtime
-(`org.kde.Platform` 6.9), which already ships Qt 6 and KSyntaxHighlighting — so
+(`org.kde.Platform` 6.10), which already ships Qt 6 and KSyntaxHighlighting — so
 the only externals built alongside mdv are md4c and QWindowKit. The manifest
 `dev.gesslar.mdv.yml` builds straight from this checkout (no pushed tag required).
 
@@ -150,7 +150,7 @@ the flathub remote configured:
 - Debian/Ubuntu: `sudo apt install flatpak flatpak-builder`
 - `flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo`
 
-The first `make flatpak` pulls `org.kde.Platform` / `org.kde.Sdk` 6.9 (a large
+The first `make flatpak` pulls `org.kde.Platform` / `org.kde.Sdk` 6.10 (a large
 one-time download). Install and run the bundle with:
 
 ```bash

--- a/dev.gesslar.mdv.yml
+++ b/dev.gesslar.mdv.yml
@@ -17,7 +17,7 @@ id: dev.gesslar.mdv
 # expects "stable" for published apps — switch this before a Flathub submission.)
 default-branch: main
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: mdv
 


### PR DESCRIPTION
Bump the Qt and KDE runtime floor from 6.9/6.11 to 6.10 across the board.

The CMake `find_package` minimum was set to 6.11, which was too aggressive — 6.11 cannot be used matrix-wide because the Flatpak job's KDE runtime (`org.kde.Platform`) tops out at 6.10 on Flathub. The floor is now consistently 6.10 everywhere:

- `CMakeLists.txt`: `find_package(Qt6 6.10 ...)` for both the main build and the Windows KSyntaxHighlighting path
- `dev.gesslar.mdv.yml`: Flatpak runtime/SDK version set to `6.10`
- `.github/workflows/release.yml`: Windows Qt install updated to `6.10.0`; Flatpak cache key updated to `mdv-flatpak-kde-6.10-*`
- `DEVELOPMENT.md`: Prerequisites and platform-specific instructions updated to reflect the 6.10 minimum

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR normalizes the Qt/KDE runtime floor to 6.10 across the entire project, replacing the previous inconsistent state where `CMakeLists.txt` required Qt 6.11 while the Windows CI installed 6.9.0 (which would have failed the CMake version gate) and the Flatpak manifest used the 6.9 runtime.

- **CMakeLists.txt**: Both `find_package(Qt6 ...)` calls lowered from 6.11 to 6.10, matching what the CI now installs and what the Flatpak runtime supplies.
- **release.yml**: Windows Qt install bumped from 6.9.0 to 6.10.0; Flatpak cache key updated to `mdv-flatpak-kde-6.10-*` (correctly busting the old 6.9 cache).
- **dev.gesslar.mdv.yml** and **DEVELOPMENT.md**: Runtime version and developer prerequisites updated to 6.10 throughout.

<h3>Confidence Score: 5/5</h3>

Safe to merge — every version reference is updated consistently and the new floor resolves a real build inconsistency.

All four files update the same version token from different prior values (6.9 in the Flatpak manifest/CI, 6.11 in CMake) to a single consistent 6.10. The old state had the Windows CI installing Qt 6.9.0 against a CMake minimum of 6.11, which would have caused a configure-time failure. The new state aligns the installed version, the CMake floor, the Flatpak runtime, and the docs. No logic changes, no new code paths, no dropped functionality.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["lowering to 6.10 to accommodate for flat..."](https://github.com/gesslar/mdv/commit/5f2f96d9ac174194b5ff0e58acdb3676dbe0b04f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34511312)</sub>

<!-- /greptile_comment -->