### PR TITLE
fix chrome theme refresh on Windows accent/scheme changes and move FindBar styling to self-contained refreshTheme

### DIFF
--- a/src/DocumentView.cpp
+++ b/src/DocumentView.cpp
@@ -152,10 +152,10 @@ DocumentView::DocumentView(QWidget *parent) : QWidget(parent) {
   connect(m_reloadTimer, &QTimer::timeout, this, &DocumentView::reloadFromDisk);
 
   // Find bar: parented to the browser so it floats over the text. Hidden until
-  // Ctrl+F. Browser resize repositions it (handled in eventFilter); theme
-  // refresh restyles it.
+  // Ctrl+F. Browser resize repositions it (handled in eventFilter). It's
+  // application chrome, so it themes itself from the system palette — no
+  // content-theme restyle hook here.
   m_findBar = new FindBar(m_browser);
-  restyleFindBar();
   m_browser->installEventFilter(this);
   connect(m_findBar, &FindBar::queryChanged, this, &DocumentView::runFind);
   connect(m_findBar, &FindBar::findNext, this, [this] { stepMatch(+1); });
@@ -238,9 +238,6 @@ void DocumentView::refresh() {
   m_browser->document()->setDefaultStyleSheet(ContentTheme::active().qss());
   applyDocumentFont();
   applyDocumentPalette();
-
-  // Colors may have changed; restyle the bar and re-tint existing highlights.
-  restyleFindBar();
 
   if(m_filePath.isEmpty()) return;
 
@@ -862,58 +859,3 @@ void DocumentView::positionFindBar() {
   m_findBar->move(x, margin);
 }
 
-void DocumentView::restyleFindBar() {
-  const ContentTheme &t = ContentTheme::active();
-  const auto colorOr = [&t](const QString &key, const QString &fallback) {
-    const QString v = t.color(key);
-    return v.isEmpty() ? fallback : v;
-  };
-  const QString bg =
-      colorOr(QStringLiteral("text.background"), QStringLiteral("#222"));
-  const QString fg =
-      colorOr(QStringLiteral("text.foreground"), QStringLiteral("#ddd"));
-  const QString fieldBg = colorOr(QStringLiteral("blockquote.background"), bg);
-  const QString err =
-      colorOr(QStringLiteral("syntax.error"), QStringLiteral("#e06c75"));
-
-  // Borders derive from the foreground at low alpha so they read as subtle
-  // dividers on either a light or dark page; the colorful accent is reserved
-  // for active toggle/hover states so the checked toggles pop.
-  QColor fgc(fg);
-  if(!fgc.isValid()) fgc = QColor(0xDD, 0xDD, 0xDD);
-  // The find bar is application chrome, not document content, so its accent
-  // follows the system/app palette rather than the markdown theme, with a
-  // defensive Highlight fallback if a platform leaves Accent unset.
-  const QPalette pal = m_findBar->palette();
-  QColor accent = pal.color(QPalette::Accent);
-  if(!accent.isValid()) accent = pal.color(QPalette::Highlight);
-
-  const auto rgba = [](const QColor &c, int alphaPct) {
-    return QStringLiteral("rgba(%1,%2,%3,%4%)")
-        .arg(c.red())
-        .arg(c.green())
-        .arg(c.blue())
-        .arg(alphaPct);
-  };
-  const QString outerBorder = rgba(fgc, 18);   // faint container edge
-  const QString fieldBorder = rgba(fgc, 32);   // visible input box edge
-  const QString tint = rgba(accent, 40);       // toggle hover
-  const QString tintStrong = rgba(accent, 70); // toggle checked
-
-  m_findBar->setStyleSheet(
-      QStringLiteral(
-          "#findBar { background-color: %1; border: 1px solid %2; "
-          "border-radius: 6px; }"
-          "#findInputFrame { background-color: %3; border: 1px solid %4; "
-          "border-radius: 4px; }"
-          "#findInputFrame[error=\"true\"] { border: 1px solid %5; }"
-          "#findInputFrame QLineEdit { background: transparent; color: %6; "
-          "border: none; }"
-          "#findBar QLabel { color: %6; }"
-          "#findBar QToolButton { color: %6; border: none; border-radius: 3px; "
-          "padding: 2px; }"
-          "#findBar QToolButton:hover { background-color: %7; }"
-          "#findBar QToolButton:checked { background-color: %8; }")
-          .arg(bg, outerBorder, fieldBg, fieldBorder, err, fg, tint,
-               tintStrong));
-}

--- a/src/DocumentView.h
+++ b/src/DocumentView.h
@@ -235,10 +235,9 @@ private:
   void clearFind();
 
   // Park the bar at the top-right of the browser (inside any vertical
-  // scrollbar) and (re)apply its themed stylesheet. Called on show, on browser
-  // resize, and on theme refresh.
+  // scrollbar). Called on show and on browser resize. The bar themes itself
+  // (system palette), so there's no restyle hook here.
   void positionFindBar();
-  void restyleFindBar();
 
   // Matches as (start, length) character offsets in document order, and the
   // index of the current one (-1 when there are none).

--- a/src/FindBar.cpp
+++ b/src/FindBar.cpp
@@ -2,14 +2,19 @@
 
 #include <QEvent>
 #include <QFont>
+#include <QGuiApplication>
 #include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QLabel>
 #include <QLineEdit>
+#include <QPalette>
 #include <QSettings>
 #include <QStyle>
+#include <QStyleHints>
+#include <QTimer>
 #include <QToolButton>
 
+#include "ChromeStyle.h"
 #include "CodiconFont.h"
 
 namespace {
@@ -98,6 +103,17 @@ FindBar::FindBar(QWidget *parent) : QFrame(parent) {
   connect(m_next, &QToolButton::clicked, this, &FindBar::findNext);
   connect(m_close, &QToolButton::clicked, this, &FindBar::deactivate);
 
+  refreshTheme();
+  connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
+          [this](Qt::ColorScheme) {
+            // On Windows colorSchemeChanged fires *before* Qt swaps the
+            // palette, so refreshing inline would re-read the old colors. Defer
+            // to the next event-loop turn, once the swap has landed.
+            QTimer::singleShot(0, this, [this] {
+              refreshTheme();
+            });
+          });
+
   hide();
 }
 
@@ -165,6 +181,54 @@ void FindBar::updateFieldState() {
   m_inputFrame->style()->polish(m_inputFrame);
 }
 
+void FindBar::refreshTheme() {
+  // The find bar is application chrome, so every color comes from the system
+  // palette (like the title bar / outline), never the document's content theme.
+  // Read the *application* palette: setStyleSheet() below folds its colors into
+  // our own palette(), so reading that would feed on the sheet we just set.
+  // Window/WindowText for the bar surface and labels (matching the rest of the
+  // chrome), Base/Text for the input box so the field reads as a distinct
+  // text-entry surface, Accent for the toggle hover/checked tints, and faint
+  // WindowText washes for the borders so they read on a light or dark desktop.
+  const QPalette pal = QGuiApplication::palette();
+  const QColor win = pal.color(QPalette::WindowText);
+  const QString bg = pal.color(QPalette::Window).name();
+  const QString fieldBg = pal.color(QPalette::Base).name();
+  const QString fg = win.name();
+  const QString fieldFg = pal.color(QPalette::Text).name();
+  const QString outerBorder = cssRgba(win, 0.18);  // faint container edge
+  const QString fieldBorder = cssRgba(win, 0.32);  // visible input box edge
+
+  QColor accent = pal.color(QPalette::Accent);
+  if(!accent.isValid()) accent = pal.color(QPalette::Highlight);
+  const QString tint = cssRgba(accent, 0.40);        // toggle hover
+  const QString tintStrong = cssRgba(accent, 0.70);  // toggle checked
+
+  // Invalid-regex border: no palette role fits, so use a fixed red that reads
+  // on both light and dark surfaces.
+  const QString err = QStringLiteral("#e06c75");
+
+  const QString sheet =
+      QStringLiteral(
+          "#findBar { background-color: %1; border: 1px solid %2; "
+          "border-radius: 6px; }"
+          "#findInputFrame { background-color: %3; border: 1px solid %4; "
+          "border-radius: 4px; }"
+          "#findInputFrame[error=\"true\"] { border: 1px solid %5; }"
+          "#findInputFrame QLineEdit { background: transparent; color: %6; "
+          "border: none; }"
+          "#findBar QLabel { color: %7; }"
+          "#findBar QToolButton { color: %7; border: none; border-radius: 3px; "
+          "padding: 2px; }"
+          "#findBar QToolButton:hover { background-color: %8; }"
+          "#findBar QToolButton:checked { background-color: %9; }")
+          .arg(bg, outerBorder, fieldBg, fieldBorder, err, fieldFg, fg, tint,
+               tintStrong);
+  // Re-applying an identical sheet re-polishes and re-emits PaletteChange,
+  // which lands back in changeEvent() — skip the no-op to break that loop.
+  if(sheet != styleSheet()) setStyleSheet(sheet);
+}
+
 bool FindBar::eventFilter(QObject *watched, QEvent *event) {
   if(watched == m_input && event->type() == QEvent::KeyPress) {
     auto *ke = static_cast<QKeyEvent *>(event);
@@ -185,4 +249,15 @@ bool FindBar::eventFilter(QObject *watched, QEvent *event) {
     }
   }
   return QFrame::eventFilter(watched, event);
+}
+
+void FindBar::changeEvent(QEvent *e) {
+  QFrame::changeEvent(e);
+  // The explicit stylesheet would otherwise stay frozen at its old colors.
+  // ApplicationPaletteChange is what Linux delivers when the app palette swaps;
+  // Windows delivers PaletteChange to the widget instead. Both arrive *after*
+  // the palette is updated, so refreshTheme() reads fresh colors either way.
+  if(e->type() == QEvent::ApplicationPaletteChange ||
+     e->type() == QEvent::PaletteChange)
+    refreshTheme();
 }

--- a/src/FindBar.h
+++ b/src/FindBar.h
@@ -56,12 +56,20 @@ signals:
 protected:
   // Field-level keys: Enter -> next, Shift+Enter -> previous, Esc -> close.
   bool eventFilter(QObject *watched, QEvent *event) override;
+  // Re-pull the stylesheet when the system palette shifts (accent or
+  // light/dark), so the bar keeps matching the surrounding chrome.
+  void changeEvent(QEvent *e) override;
 
 private:
   // Build a checkable codicon toggle wired to <settingsKey>, seeded from and
   // written back to QSettings, emitting queryChanged() on toggle.
   QToolButton *makeToggle(char16_t glyph, const QString &fallback,
                           const QString &tip, const QString &settingsKey);
+
+  // Rebuild the bar's stylesheet from the system palette. The find bar is
+  // application chrome, so it follows the desktop theme — never the document's
+  // content theme.
+  void refreshTheme();
 
   // Recolor the field per m_regexError without clobbering the themed stylesheet
   // the owner applies to the bar.

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -18,6 +18,7 @@
 #include <QSignalBlocker>
 #include <QStatusBar>
 #include <QStyleHints>
+#include <QTimer>
 #include <QToolButton>
 #include <QUrl>
 #include <QVBoxLayout>
@@ -205,9 +206,15 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
   refreshStatusBarStyle();
   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
           [this](Qt::ColorScheme) {
-            refreshStatusBarStyle();
+            // On Windows colorSchemeChanged fires *before* Qt swaps the
+            // palette, so refreshing inline would re-read the old (light)
+            // colors. Defer to the next event-loop turn, once the swap lands.
+            QTimer::singleShot(0, this, [this] {
+              refreshStatusBarStyle();
+            });
             // When following the system scheme, the active content theme
-            // tracks it — reload and re-render every open document.
+            // tracks it — reload and re-render every open document. This reads
+            // colorScheme() directly (not the palette), so it's fine inline.
             if(QSettings()
                    .value(QStringLiteral("theme/followSystem"), false)
                    .toBool()) {
@@ -435,14 +442,18 @@ void MainWindow::refreshStatusBarStyle() {
   // WindowText washes for hover/press (which read on any scheme). Zero
   // vertical padding lets the status bar center the button to text height;
   // horizontal padding gives the hover pill room while keeping a small inset.
-  const QPalette pal = palette();
+  // Read the application palette, not this window's palette() — the explicit
+  // stylesheet below folds its colors back into the widget palette, so reading
+  // our own would feed on the sheet we just set. The app palette is the clean
+  // system source.
+  const QPalette pal = QGuiApplication::palette();
   const QColor txt = pal.color(QPalette::WindowText);
   const QString fg = txt.name();
   const QString dis =
       pal.color(QPalette::Disabled, QPalette::WindowText).name();
   const QString hover = cssRgba(txt, 0.18);
   const QString press = cssRgba(txt, 0.30);
-  statusBar()->setStyleSheet(
+  const QString sheet =
       QStringLiteral(
           "QStatusBar { color: %1; }"
           "QStatusBar::item { border: none; }"
@@ -451,14 +462,19 @@ void MainWindow::refreshStatusBarStyle() {
           "QStatusBar QToolButton:disabled { color: %2; }"
           "QStatusBar QToolButton:enabled:hover { background: %3; }"
           "QStatusBar QToolButton:enabled:pressed { background: %4; }")
-          .arg(fg, dis, hover, press));
+          .arg(fg, dis, hover, press);
+  if(sheet != statusBar()->styleSheet()) statusBar()->setStyleSheet(sheet);
 }
 
 void MainWindow::changeEvent(QEvent *e) {
   QMainWindow::changeEvent(e);
-  // ApplicationPaletteChange covers both accent and light/dark shifts; the
-  // explicit stylesheet would otherwise stay frozen at its old colors.
-  if(e->type() == QEvent::ApplicationPaletteChange) refreshStatusBarStyle();
+  // The explicit stylesheet would otherwise stay frozen at its old colors.
+  // ApplicationPaletteChange is what Linux delivers when the app palette swaps;
+  // Windows delivers PaletteChange to the widget instead. Both arrive *after*
+  // the palette is updated, so refreshStatusBarStyle() reads fresh colors.
+  if(e->type() == QEvent::ApplicationPaletteChange ||
+     e->type() == QEvent::PaletteChange)
+    refreshStatusBarStyle();
 }
 
 void MainWindow::onCurrentDocumentChanged(DocumentView *doc) {

--- a/src/OutlinePanel.cpp
+++ b/src/OutlinePanel.cpp
@@ -5,17 +5,47 @@
 #include <QFont>
 #include <QGuiApplication>
 #include <QHBoxLayout>
+#include <QHelpEvent>
 #include <QLabel>
 #include <QMenu>
+#include <QPainter>
 #include <QPalette>
+#include <QProxyStyle>
 #include <QStyleHints>
+#include <QStyleOption>
+#include <QStyleOptionViewItem>
+#include <QTimer>
 #include <QToolButton>
+#include <QToolTip>
 #include <QTreeWidget>
 #include <QTreeWidgetItem>
 #include <QVBoxLayout>
 
 #include "ChromeStyle.h"
 #include "CodiconFont.h"
+
+namespace {
+
+// The Windows 11 style paints a vertical accent "pill" at the left edge of a
+// selected/current item-view row. We already render selection as a full-row
+// wash via the stylesheet; the native pill sits at the same left edge as the
+// expand chevron (so it collides on flush/root rows) and doesn't exist on other
+// platforms at all. Suppressing just this primitive makes selection read the
+// same everywhere — the stylesheet still draws the row background, so nothing
+// else changes.
+class NoSelectionPillStyle : public QProxyStyle {
+public:
+  using QProxyStyle::QProxyStyle;
+
+  void drawPrimitive(PrimitiveElement pe, const QStyleOption *opt, QPainter *p,
+                     const QWidget *w) const override {
+    if(pe == QStyle::PE_PanelItemViewItem || pe == QStyle::PE_PanelItemViewRow)
+      return;
+    QProxyStyle::drawPrimitive(pe, opt, p, w);
+  }
+};
+
+}  // namespace
 
 OutlinePanel::OutlinePanel(QWidget *parent) : QWidget(parent) {
   setObjectName(QStringLiteral("OutlinePanel"));
@@ -75,6 +105,13 @@ OutlinePanel::OutlinePanel(QWidget *parent) : QWidget(parent) {
   m_tree->setSelectionMode(QAbstractItemView::SingleSelection);
   m_tree->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   m_tree->setExpandsOnDoubleClick(false);
+  // Drop the Windows 11 selection accent pill (see NoSelectionPillStyle); the
+  // proxy is parented to the tree so it lives exactly as long.
+  auto *treeStyle = new NoSelectionPillStyle;
+  treeStyle->setParent(m_tree);
+  m_tree->setStyle(treeStyle);
+  // Watch the viewport so we can show a tooltip on elided rows only.
+  m_tree->viewport()->installEventFilter(this);
   connect(m_tree, &QTreeWidget::itemClicked, this,
           [this](QTreeWidgetItem *item, int /*column*/) {
             const QString id = item->data(0, Qt::UserRole).toString();
@@ -94,7 +131,13 @@ OutlinePanel::OutlinePanel(QWidget *parent) : QWidget(parent) {
   refreshTheme();
   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
           [this](Qt::ColorScheme) {
-            refreshTheme();
+            // On Windows colorSchemeChanged fires *before* Qt swaps the
+            // palette, so refreshing inline would re-read the old (light)
+            // colors. Defer to the next event-loop turn, by which point the
+            // palette swap has landed and the read is fresh.
+            QTimer::singleShot(0, this, [this] {
+              refreshTheme();
+            });
           });
 }
 
@@ -145,12 +188,15 @@ void OutlinePanel::setCurrentHeading(const QString &anchorId) {
 }
 
 void OutlinePanel::refreshTheme() {
-  // All colors come from the system palette so the panel matches the rest of
-  // the chrome and follows accent/scheme changes: Window/WindowText for the
-  // surface and rows, PlaceholderText for the muted title/placeholder, a
-  // translucent WindowText wash for hover, and the real Highlight/
-  // HighlightedText pair for the selected row so selection tracks the accent.
-  const QPalette pal = palette();
+  // Colors come from the *application* palette, not this widget's palette():
+  // setStyleSheet() below folds its colors back into the widget palette, so
+  // reading our own palette would feed on the stylesheet we just set. The app
+  // palette is the clean system source, so the panel matches the rest of the
+  // chrome and follows accent/scheme changes: Window/WindowText for the surface
+  // and rows, PlaceholderText for the muted title/placeholder, a translucent
+  // WindowText wash for hover, and the real Highlight for the selected row so
+  // selection tracks the accent.
+  const QPalette pal = QGuiApplication::palette();
   const QColor txt = pal.color(QPalette::WindowText);
   const QColor place = pal.color(QPalette::PlaceholderText);
   const QString bg = pal.color(QPalette::Window).name();
@@ -161,7 +207,7 @@ void OutlinePanel::refreshTheme() {
   // softer and normal WindowText reads better on it than HighlightedText.
   const QString sel = cssRgba(pal.color(QPalette::Highlight), 0.5);
 
-  setStyleSheet(QStringLiteral(R"(
+  const QString sheet = QStringLiteral(R"(
 OutlinePanel, #outlineHeader { background: %1; }
 #outlineTitle { color: %3; font-size: 11px; font-weight: 600; }
 QToolButton#outlineCollapse {
@@ -176,12 +222,55 @@ QTreeWidget#outlineTree::item { padding: 3px 2px; border: none; }
 QTreeWidget#outlineTree::item:hover { background: %4; }
 QTreeWidget#outlineTree::item:selected { background: %5; color: %2; }
 )")
-                    .arg(bg, fg, muted, hover, sel));
+                          .arg(bg, fg, muted, hover, sel);
+  // Re-applying an identical sheet re-polishes and re-emits PaletteChange,
+  // which lands back in changeEvent() — skip the no-op to break that loop.
+  if(sheet != styleSheet()) setStyleSheet(sheet);
 }
 
 void OutlinePanel::changeEvent(QEvent *e) {
   QWidget::changeEvent(e);
-  // ApplicationPaletteChange covers both accent and light/dark shifts; the
-  // explicit stylesheet would otherwise stay frozen at its old colors.
-  if(e->type() == QEvent::ApplicationPaletteChange) refreshTheme();
+  // The explicit stylesheet would otherwise stay frozen at its old colors.
+  // ApplicationPaletteChange is what Linux delivers when the app palette swaps;
+  // Windows delivers PaletteChange to the widget instead. Both arrive *after*
+  // the palette is updated, so refreshTheme() reads fresh colors either way.
+  if(e->type() == QEvent::ApplicationPaletteChange ||
+     e->type() == QEvent::PaletteChange)
+    refreshTheme();
+}
+
+bool OutlinePanel::eventFilter(QObject *obj, QEvent *e) {
+  if(obj == m_tree->viewport() && e->type() == QEvent::ToolTip) {
+    auto *help = static_cast<QHelpEvent *>(e);
+    const QModelIndex idx = m_tree->indexAt(help->pos());
+    if(idx.isValid()) {
+      // Replicate the view's own elision test so the tooltip appears exactly
+      // when the label is truncated. The style gives the text sub-rect inside
+      // the (indented, QSS-padded) cell; the delegate then trims a text margin
+      // of PM_FocusFrameHMargin+1 per side before eliding. Measuring the full
+      // label against that same width matches the draw decision to the pixel —
+      // a plain visualRect/sizeHint estimate misses borderline rows.
+      const QString text = idx.data(Qt::DisplayRole).toString();
+      const QRect cell = m_tree->visualRect(idx);
+      QStyleOptionViewItem opt;
+      opt.initFrom(m_tree);
+      opt.rect = cell;
+      opt.features |= QStyleOptionViewItem::HasDisplay;
+      opt.text = text;
+      QStyle *st = m_tree->style();
+      const QRect textRect =
+          st->subElementRect(QStyle::SE_ItemViewItemText, &opt, m_tree);
+      const int textMargin =
+          st->pixelMetric(QStyle::PM_FocusFrameHMargin, &opt, m_tree) + 1;
+      const int available = textRect.width() - 2 * textMargin;
+      if(opt.fontMetrics.horizontalAdvance(text) > available)
+        QToolTip::showText(help->globalPos(), text, m_tree, cell);
+      else
+        QToolTip::hideText();
+    } else {
+      QToolTip::hideText();
+    }
+    return true;  // we own tooltip behaviour for the tree
+  }
+  return QWidget::eventFilter(obj, e);
 }

--- a/src/OutlinePanel.h
+++ b/src/OutlinePanel.h
@@ -44,6 +44,9 @@ protected:
   // Re-pull the stylesheet when the system palette shifts (accent or
   // light/dark), so the panel keeps matching the surrounding chrome.
   void changeEvent(QEvent *e) override;
+  // Tree-viewport tooltips: show the full heading text only when the row is too
+  // narrow to display it (i.e. the label is elided).
+  bool eventFilter(QObject *obj, QEvent *e) override;
 
 private:
   void refreshTheme();

--- a/src/TitleBar.cpp
+++ b/src/TitleBar.cpp
@@ -9,6 +9,7 @@
 #include <QPalette>
 #include <QStyle>
 #include <QStyleHints>
+#include <QTimer>
 #include <QToolButton>
 
 #include "ChromeStyle.h"
@@ -98,24 +99,32 @@ TitleBar::TitleBar(QWidget *parent) : QWidget(parent) {
   refreshTheme();
   connect(QGuiApplication::styleHints(), &QStyleHints::colorSchemeChanged, this,
           [this](Qt::ColorScheme) {
-            refreshTheme();
+            // On Windows colorSchemeChanged fires *before* Qt swaps the
+            // palette, so refreshing inline would re-read the old (light)
+            // colors. Defer to the next event-loop turn, by which point the
+            // palette swap has landed and the read is fresh.
+            QTimer::singleShot(0, this, [this] {
+              refreshTheme();
+            });
           });
 }
 
 void TitleBar::refreshTheme() {
-  // Title bar colors come straight from the system palette so it belongs to
-  // the desktop and shifts with it — Window/WindowText for the surface, with
-  // hover/press as translucent WindowText washes that read on any scheme.
-  // Close button hover stays the canonical Win11 red regardless of scheme; the
+  // Colors come from the *application* palette, not this widget's palette():
+  // setStyleSheet() below folds its colors back into the widget palette, so
+  // reading our own palette would feed on the stylesheet we just set. The app
+  // palette is the clean system source — Window/WindowText for the surface,
+  // hover/press as translucent WindowText washes that read on any scheme. Close
+  // button hover stays the canonical Win11 red regardless of scheme; the
   // menu-indicator chevron is suppressed so the buttons read as labels.
-  const QPalette pal = palette();
+  const QPalette pal = QGuiApplication::palette();
   const QString bg = pal.color(QPalette::Window).name();
   const QString fg = pal.color(QPalette::WindowText).name();
   const QColor txt = pal.color(QPalette::WindowText);
   const QString hover = cssRgba(txt, 0.10);
   const QString press = cssRgba(txt, 0.16);
 
-  setStyleSheet(QStringLiteral(R"(
+  const QString sheet = QStringLiteral(R"(
 TitleBar { background: %1; }
 TitleBar QToolButton {
     background: transparent;
@@ -129,14 +138,21 @@ TitleBar QToolButton#sysClose:hover { background: #c42b1c; color: white; }
 TitleBar QToolButton#sysClose:pressed { background: #b4271a; color: white; }
 TitleBar QToolButton::menu-indicator { image: none; }
 )")
-                    .arg(bg, fg, hover, press));
+                          .arg(bg, fg, hover, press);
+  // Re-applying an identical sheet re-polishes and re-emits PaletteChange,
+  // which lands back in changeEvent() — skip the no-op to break that loop.
+  if(sheet != styleSheet()) setStyleSheet(sheet);
 }
 
 void TitleBar::changeEvent(QEvent *e) {
   QWidget::changeEvent(e);
-  // ApplicationPaletteChange covers both accent and light/dark shifts; the
-  // explicit stylesheet would otherwise stay frozen at its old colors.
-  if(e->type() == QEvent::ApplicationPaletteChange) refreshTheme();
+  // The explicit stylesheet would otherwise stay frozen at its old colors.
+  // ApplicationPaletteChange is what Linux delivers when the app palette swaps;
+  // Windows delivers PaletteChange to the widget instead. Both arrive *after*
+  // the palette is updated, so refreshTheme() reads fresh colors either way.
+  if(e->type() == QEvent::ApplicationPaletteChange ||
+     e->type() == QEvent::PaletteChange)
+    refreshTheme();
 }
 
 void TitleBar::setFileMenu(QMenu *menu) { m_fileBtn->setMenu(menu); }

--- a/src/WindowsChrome.cpp
+++ b/src/WindowsChrome.cpp
@@ -3,8 +3,13 @@
 #include <QWidget>
 
 #ifdef Q_OS_WIN
+#include <cwchar>
+
+#include <QAbstractNativeEventFilter>
+#include <QApplication>
 #include <QGuiApplication>
 #include <QStyleHints>
+#include <QTimer>
 // clang-format off
 // windows.h must precede dwmapi.h (and other Windows SDK headers) — they use
 // types it defines. Fenced so the include sorter can't alphabetize them back
@@ -27,6 +32,11 @@
 #ifndef DWMSBT_MAINWINDOW
 #define DWMSBT_MAINWINDOW 2
 #endif
+// Accent/colorization change broadcast. Defined in winuser.h on current SDKs;
+// kept as a fallback for older MinGW headers that predate it.
+#ifndef WM_DWMCOLORIZATIONCOLORCHANGED
+#define WM_DWMCOLORIZATIONCOLORCHANGED 0x0320
+#endif
 
 namespace {
 void writeDwmAttrs(QWidget *w) {
@@ -46,6 +56,46 @@ void writeDwmAttrs(QWidget *w) {
   DwmSetWindowAttribute(hwnd, DWMWA_SYSTEMBACKDROP_TYPE, &backdrop,
                         sizeof(backdrop));
 }
+
+// Re-send ApplicationPaletteChange to every widget so palette-derived
+// stylesheets re-read QGuiApplication::palette() (which Qt has already updated
+// from the system). Qt normally does this itself, but a QWindowKit frameless
+// window can swallow the propagation to its children — this heals that gap.
+void broadcastPaletteRefresh() {
+  QEvent ev(QEvent::ApplicationPaletteChange);
+  const auto widgets = QApplication::allWidgets();
+  for(QWidget *w : widgets) QApplication::sendEvent(w, &ev);
+}
+
+// Watches the system color-scheme / accent change messages. WM_SETTINGCHANGE
+// with "ImmersiveColorSet" covers light/dark (and accent on some builds);
+// WM_DWMCOLORIZATIONCOLORCHANGED is the dedicated accent/colorization message.
+// Both are broadcast to top-level windows, so the app window's filter sees them
+// even when QWindowKit owns the frame.
+class ColorSettingsFilter : public QAbstractNativeEventFilter {
+public:
+  bool nativeEventFilter(const QByteArray &type, void *message,
+                         qintptr * /*result*/) override {
+    if(type != "windows_generic_MSG" && type != "windows_dispatcher_MSG")
+      return false;
+    const auto *msg = static_cast<const MSG *>(message);
+
+    const bool accent = msg->message == WM_DWMCOLORIZATIONCOLORCHANGED;
+    const bool settings =
+        msg->message == WM_SETTINGCHANGE && msg->lParam != 0 &&
+        std::wcscmp(reinterpret_cast<const wchar_t *>(msg->lParam),
+                    L"ImmersiveColorSet") == 0;
+
+    if(accent || settings) {
+      // Defer: let Qt's own handler update QGuiApplication::palette() on this
+      // same message first, then re-broadcast so the chrome reads fresh colors.
+      QTimer::singleShot(0, qApp, [] {
+        broadcastPaletteRefresh();
+      });
+    }
+    return false;  // never consume — Qt and QWindowKit still need the message
+  }
+};
 }  // namespace
 #endif
 
@@ -62,5 +112,20 @@ void applyWindowsChrome(QWidget *w) {
                    });
 #else
   (void)w;
+#endif
+}
+
+void installChromeThemeTracker() {
+#ifdef Q_OS_WIN
+  // Lives for the process lifetime; qApp outlives any single window, so the
+  // filter is safe to leave installed until shutdown. Guard against a second
+  // call (a future refactor calling this from two places): Qt doesn't
+  // deduplicate native event filters, so installing twice would fire
+  // broadcastPaletteRefresh() twice per color-change message.
+  static bool installed = false;
+  if(installed) return;
+  installed = true;
+  static ColorSettingsFilter filter;
+  qApp->installNativeEventFilter(&filter);
 #endif
 }

--- a/src/WindowsChrome.h
+++ b/src/WindowsChrome.h
@@ -21,3 +21,19 @@ class QWidget;
 // Caller's responsibility: ensure the widget has a native HWND
 // (e.g. (void)w->winId()) before calling.
 void applyWindowsChrome(QWidget *w);
+
+// Install an application-wide tracker that re-broadcasts a palette refresh to
+// every widget whenever Windows changes its color scheme or accent color.
+//
+// Why this is needed: Qt keeps QGuiApplication::palette() in sync with the
+// system accent/scheme, but inside a QWindowKit frameless window the follow-up
+// ApplicationPaletteChange doesn't reliably reach the child widgets — so the
+// chrome's palette-derived stylesheets freeze at their load-time colors (most
+// visibly, accent changes do nothing). The accent has no QStyleHints signal at
+// all, so colorSchemeChanged can't cover it. This watches the native
+// WM_SETTINGCHANGE / WM_DWMCOLORIZATIONCOLORCHANGED messages and, once Qt has
+// updated its palette, re-sends ApplicationPaletteChange so the chrome re-reads
+// the fresh colors. Call once, after QApplication is constructed.
+//
+// No-op on non-Windows builds (those platforms deliver the event normally).
+void installChromeThemeTracker();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <QIcon>
 
 #include "MainWindow.h"
+#include "WindowsChrome.h"
 
 int main(int argc, char *argv[]) {
   // QWindowKit's WidgetWindowAgent requires this be set before QApplication
@@ -24,6 +25,11 @@ int main(int argc, char *argv[]) {
   // resources/dev.gesslar.mdv.desktop).
   app.setWindowIcon(QIcon(QStringLiteral(":/icons/mdv.png")));
   QGuiApplication::setDesktopFileName(QStringLiteral("dev.gesslar.mdv"));
+
+  // Re-broadcast system color-scheme / accent changes into our frameless
+  // window, whose QWindowKit chrome otherwise swallows the palette-change
+  // propagation (no-op off Windows).
+  installChromeThemeTracker();
 
   QCommandLineParser parser;
   parser.setApplicationDescription("An offline Markdown viewer.");


### PR DESCRIPTION
Fix palette-derived stylesheets freezing when the system accent or color scheme changes

Chrome widgets (title bar, status bar, outline panel, find bar) build their stylesheets from palette colors at construction time. Two problems caused those stylesheets to go stale:

1. **Palette feedback loop**: Each widget was reading its own `palette()` to build the stylesheet, but `setStyleSheet()` folds colors back into the widget palette — so subsequent reads would consume the stylesheet's own colors rather than the fresh system source. All theme reads are now taken from `QGuiApplication::palette()` instead.

2. **Missed palette-change events**: `changeEvent()` handlers were only responding to `ApplicationPaletteChange`, which is what Linux delivers. Windows delivers `PaletteChange` to the widget directly. Both event types now trigger a theme refresh. Additionally, `colorSchemeChanged` fires on Windows *before* Qt has swapped the palette, so all `colorSchemeChanged` handlers now defer their refresh via `QTimer::singleShot(0, ...)` to let Qt's own handler update the palette first.

3. **QWindowKit propagation gap**: Inside a QWindowKit frameless window, the `ApplicationPaletteChange` event doesn't reliably reach child widgets after a system accent or scheme change. A new `ColorSettingsFilter` native event filter watches `WM_SETTINGCHANGE` (`ImmersiveColorSet`) and `WM_DWMCOLORIZATIONCOLORCHANGED`, then re-broadcasts `ApplicationPaletteChange` to all widgets once Qt has updated its palette. This is installed once at startup via `installChromeThemeTracker()` and is a no-op on non-Windows builds.

4. **Redundant stylesheet re-application loop**: Re-applying an identical stylesheet triggers re-polishing and re-emits `PaletteChange`, which would call the theme refresh again. Each `refreshTheme()` now compares the new sheet against the current one and skips `setStyleSheet()` if nothing changed.

The find bar's theming responsibility has also been moved from `DocumentView` into `FindBar` itself. The bar now owns its `refreshTheme()` method, hooks `colorSchemeChanged` and `changeEvent()` internally, and no longer requires `DocumentView::restyleFindBar()` or a call during `refresh()`. Since the find bar is application chrome rather than document content, it should never have been restyled from the content theme.

The outline panel gains elision-aware tooltips: a viewport event filter intercepts `ToolTip` events on tree rows, measures the label against the available text rect (matching the delegate's own elision calculation), and shows the full heading text only when the row is actually truncated. A `NoSelectionPillStyle` proxy is also applied to the tree to suppress the Windows 11 native selection accent pill, which collides with the expand chevron on root rows and is inconsistent with other platforms.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes palette-derived stylesheets freezing when Windows changes its system accent color or light/dark scheme inside a QWindowKit frameless window. It also migrates `FindBar` theming from `DocumentView` into `FindBar` itself, adds elision-aware tooltips to the outline tree, and suppresses the Windows 11 selection accent pill on the tree.

- **Palette source fix**: All chrome widgets (`TitleBar`, `OutlinePanel`, `FindBar`, `MainWindow` status bar) now read `QGuiApplication::palette()` instead of `this->palette()` to break the feedback loop where `setStyleSheet()` folded colors back into the widget's own palette. Identical-sheet guards prevent redundant re-polishing.
- **Windows event coverage**: `changeEvent()` handlers now respond to both `ApplicationPaletteChange` (Linux) and `PaletteChange` (Windows widget-direct delivery). A new `ColorSettingsFilter` native event filter watches `WM_SETTINGCHANGE (ImmersiveColorSet)` and `WM_DWMCOLORIZATIONCOLORCHANGED`, deferring a full `broadcastPaletteRefresh()` to close the QWindowKit propagation gap. All `colorSchemeChanged` handlers now defer via `QTimer::singleShot(0)` so Qt's own palette update lands first.
- **FindBar self-contained theming**: `DocumentView::restyleFindBar()` removed; `FindBar` now owns `refreshTheme()`, wires `colorSchemeChanged`, and handles `changeEvent()` internally.

<h3>Confidence Score: 4/5</h3>

Safe to merge on all platforms except Windows, where the new native event filter has one incorrect check that could dereference an arbitrary memory address.

The WM_SETTINGCHANGE handler in the new ColorSettingsFilter casts msg->lParam to const wchar_t * and calls std::wcscmp without first verifying that msg->wParam == 0. Windows only guarantees lParam is a string pointer when wParam is zero; when wParam is a non-zero SPI_* value, lParam may be a struct pointer or a small handle-like integer. Attempting wcscmp on a small, non-dereferenceable address is an access violation.

src/WindowsChrome.cpp — the WM_SETTINGCHANGE lParam string cast needs a wParam == 0 guard added before the std::wcscmp call.

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2FWindowsChrome.cpp%3A84-87%0AThe%20%60WM_SETTINGCHANGE%60%20check%20is%20missing%20a%20%60wParam%20%3D%3D%200%60%20guard%20before%20treating%20%60lParam%60%20as%20a%20string%20pointer.%20Per%20the%20Windows%20API%20spec%2C%20%60lParam%60%20is%20a%20string%20only%20when%20%60wParam%20%3D%3D%200%60%3B%20when%20%60wParam%60%20is%20a%20non-zero%20%60SPI_*%60%20constant%2C%20%60lParam%60%20may%20be%20a%20struct%20pointer%20or%20a%20small%20integer%20handle.%20Casting%20an%20arbitrary%20non-null%20%60lParam%60%20to%20%60const%20wchar_t%20*%60%20and%20calling%20%60std%3A%3Awcscmp%60%20on%20it%20is%20undefined%20behaviour%20%E2%80%94%20if%20%60lParam%60%20holds%20a%20small%2C%20non-dereferenceable%20value%20%28e.g.%2C%20a%20handle%29%2C%20it%20will%20access-violate%20at%20runtime.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20bool%20settings%20%3D%0A%20%20%20%20%20%20%20%20msg-%3Emessage%20%3D%3D%20WM_SETTINGCHANGE%20%26%26%20msg-%3EwParam%20%3D%3D%200%20%26%26%0A%20%20%20%20%20%20%20%20msg-%3ElParam%20!%3D%200%20%26%26%0A%20%20%20%20%20%20%20%20std%3A%3Awcscmp%28reinterpret_cast%3Cconst%20wchar_t%20*%3E%28msg-%3ElParam%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20L%22ImmersiveColorSet%22%29%20%3D%3D%200%3B%0A%60%60%60%0A%0A&repo=gesslar%2Fmdv&pr=41&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fixes"](https://github.com/gesslar/mdv/commit/4ed39e279417d40a51cd57abf67cee02c162d388) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34520695)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->